### PR TITLE
🦺(test) Run as root and run as user can be set on container level

### DIFF
--- a/policy/containers.rego
+++ b/policy/containers.rego
@@ -4,9 +4,21 @@ import rego.v1
 deny contains msg if {
   input.kind in {"Deployment", "StatefulSet", "DaemonSet", "Job", "Pod"}
   input.spec.template.spec.securityContext.runAsUser == 0
+  input.spec.template.spec.containers[_].securityContext.runAsUser == 0
 
-  msg := "Containers must not run as root"
+  msg := "Containers must not run as root, check runAsUser"
 }
+
+# Disallow containers running as root (already present, but improved)
+deny contains msg if {
+  input.kind in {"Deployment", "StatefulSet", "DaemonSet", "Job", "Pod"}
+  not input.spec.template.spec.securityContext.runAsNonRoot
+  every container in input.spec.template.spec.containers {
+    not container.securityContext.runAsNonRoot
+  }
+  msg := "Containers must not run as root, check runAsNonRoot"
+}
+
 
 #disallow latest tag
 deny contains msg if {
@@ -61,13 +73,6 @@ deny contains msg if {
   some v
   input.spec.template.spec.volumes[v].hostPath
   msg := "hostPath volumes are not allowed"
-}
-
-# Disallow containers running as root (already present, but improved)
-deny contains msg if {
-  input.kind in {"Deployment", "StatefulSet", "DaemonSet", "Job", "Pod"}
-  not input.spec.template.spec.securityContext.runAsNonRoot
-  msg := "Containers must not run as root"
 }
 
 # Disallow containers with allowPrivilegeEscalation: true


### PR DESCRIPTION
# Description

The rule for checking whether containers run as root were only checked at the spec-level. But these settings can also be supplied at the spec.containers sublevel. This also seems valid, so the rules should check for this.

Resolves #25

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x] I have followed the project's style guidelines by running the relevent scripts/\* tools.
- [x] I have rebased my branch onto the latest commit of the main branch.
- [x] I have squashed or reorganized my commits into logical units.
