### PR TITLE
👷(ci) Remove check-changelog dependency from CI workflow

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -21,6 +21,3 @@ changelog:
     - title: Other Changes
       labels:
         - "*"
-
-
-

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -304,7 +304,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       [
-        check-changelog,
         lint-commit-messages,
         check-format-rules,
         render-helmfile,

--- a/.gitlint
+++ b/.gitlint
@@ -2,9 +2,6 @@
 ignore=B6
 regex-style-search=True
 extra-path=scripts/gitlint_emoji.py
-ignore-merge-commits=False
-ignore-fixup-commits=False
-ignore-squash-commits=False
 
 
 [title-max-length]

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ We are actively expanding the suite and plan to add even more capabilities, incl
 
 This repo uses the [gitmoji](https://gitmoji.dev/) commit convention with the following scopes:
 
-1. folder names in helmfile/apps/* (the products)
+1. folder names in helmfile/apps/\* (the products)
 2. settings: update settings (not related to 1 product)
 3. deps: update dependencies (not related to 1 product)
 4. docs: documentation update (not related to 1 product)


### PR DESCRIPTION
# Description

Mistake in previous PR. Now the CI is broken. This fixes the issue where there is no existing changelog job

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x] I have followed the project's style guidelines by running the relevant scripts/\* tools.
- [x] I have rebased my branch onto the latest commit of the main branch.
- [x] I have squashed or reorganized my commits into logical units.
- [x] I have updated documentation.
