### PR TITLE
🐛(chat) Fix synapse security configuration indentation

### DIFF
--- a/helmfile/apps/chat/values-synapse.yaml.gotmpl
+++ b/helmfile/apps/chat/values-synapse.yaml.gotmpl
@@ -116,8 +116,8 @@ worker:
                   app.kubernetes.io/instance: chat-postgresql
           {{- end }}
         {{- end }}
-    podSecurityContext: {{ .Values.security.default.podSecurityContext | toYaml | nindent 4 }}
-    containerSecurityContext: {{ .Values.security.default.containerSecurityContext | toYaml | nindent 4 }}
+    podSecurityContext: {{ .Values.security.default.podSecurityContext | toYaml | nindent 6 }}
+    containerSecurityContext: {{ .Values.security.default.containerSecurityContext | toYaml | nindent 6 }}
   generic_worker:
     enabled: true
   media_repository:


### PR DESCRIPTION
# Description

Indentation for `podSecurityContext` and `containerSecurityContext` of the default worker configution for Synapse is incorrect. I should be 6 in stead of 4.

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x] I have followed the project's style guidelines by running the relevant scripts/\* tools.
- [x] I have rebased my branch onto the latest commit of the main branch.
- [x] I have squashed or reorganized my commits into logical units.
- [x] I have updated documentation.
