### PR TITLE
🐛(grist) enable oidc by default

### DIFF
--- a/helmfile/apps/grist/values.yaml.gotmpl
+++ b/helmfile/apps/grist/values.yaml.gotmpl
@@ -11,7 +11,7 @@ image:
   tag: {{ .Values.container.grist.tag | quote }}
 
 auth:
-  enabled: false
+  enabled: true
   oidcIdpIssuer: {{ .Values.authentication.oidc.issuer | quote }}
   oidcIdpClientId: {{ .Values.authentication.client.grist.client_id | quote }}
   oidcIdpClientSecret: {{ .Values.authentication.client.grist.client_secret | quote }}


### PR DESCRIPTION
# Description

OIDC is enabled by default for other applications, so it makes sense its also by default enabled for grist.

Resolves #

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x] I have followed the project's style guidelines by running the relevant scripts/\* tools.
- [x] I have rebased my branch onto the latest commit of the main branch.
- [x] I have squashed or reorganized my commits into logical units.
- [x] I have updated documentation.
