### PR TITLE
🐛(other) Correct regex pattern for deps in GitmojiTitle validation

### DIFF
--- a/scripts/gitlint_emoji.py
+++ b/scripts/gitlint_emoji.py
@@ -37,7 +37,7 @@ class GitmojiTitle(LineRule):
             violation_msg = 'Title does not match regex "<gitmoji>(<scope>) <subject>"'
 
             # Special case for deps, updatecli forces a : after deps
-            depspattern = r"^({:s})\(deps):\s[a-zA-Z].*$".format("|".join(emojis))
+            depspattern = r"^({:s})\(deps\):\s[a-zA-Z].*$".format("|".join(emojis))
             if not re.search(depspattern, title):
               return [RuleViolation(self.id, violation_msg, title)]
 


### PR DESCRIPTION
# Description

Fix bug in regex for gitlint

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x] I have followed the project's style guidelines by running the relevant scripts/\* tools.
- [x] I have rebased my branch onto the latest commit of the main branch.
- [x] I have squashed or reorganized my commits into logical units.
- [x] I have updated documentation.
