### PR TITLE
✅(policies) Fix service account name policy for pod resources

### DIFF
--- a/policy/containers.rego
+++ b/policy/containers.rego
@@ -145,8 +145,13 @@ deny contains msg if {
 
 # Disallow use of default service account
 deny contains msg if {
-  input.kind in {"Deployment", "StatefulSet", "DaemonSet", "Job", "Pod"}
+  input.kind in {"Deployment", "StatefulSet", "DaemonSet", "Job"}
   not input.spec.template.spec.serviceAccountName
+  msg := "A custom service account must be specified (do not use default)"
+}
+deny contains msg if {
+  input.kind in {"Pod"}
+  not input.spec.serviceAccountName
   msg := "A custom service account must be specified (do not use default)"
 }
 


### PR DESCRIPTION
# Description

Pods set their service account name at a different level than other resources. Change the policy to reflect this.

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x] I have followed the project's style guidelines by running the relevant scripts/\* tools.
- [x] I have rebased my branch onto the latest commit of the main branch.
- [x] I have squashed or reorganized my commits into logical units.
- [x] I have updated documentation.
