### PR TITLE
🐛(element) Add .well-known ingress path

### DIFF
--- a/helmfile/apps/element/charts/synapse/templates/ingress.yaml
+++ b/helmfile/apps/element/charts/synapse/templates/ingress.yaml
@@ -40,20 +40,23 @@ spec:
           {{- range $config.csPaths }}
           - path: {{ . | quote }}
             pathType: {{ $.Values.ingress.pathType }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" $service "servicePort" "listener" "context" $)  | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" $service "servicePort" "listener" "context" $) | nindent 14 }}
           {{- end }}
           {{- end }}
           {{- end }}
           {{- end }}
-
           - path: /_matrix
             pathType: {{ .Values.ingress.pathType }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" $fullName "servicePort" "http" "context" .)  | nindent 14 }}
-
+            backend: {{- include "common.ingress.backend" (dict "serviceName" $fullName "servicePort" "http" "context" .) | nindent 14 }}
+          {{- if .Values.synapse.serveServerWellknown }}
+          - path: /.well-known
+            pathType: {{ .Values.ingress.pathType }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" $fullName "servicePort" "http" "context" .) | nindent 14 }}
+          {{- end }}
           {{- if .Values.ingress.includeSynapseAdminApis }}
           - path: /_synapse
             pathType: {{ .Values.ingress.pathType }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" $fullName "servicePort" "http" "context" .)  | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" $fullName "servicePort" "http" "context" .) | nindent 14 }}
           {{- end }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}


### PR DESCRIPTION
# Description

Allow requests to `/.well-known` uri's to the server via Ingress. This is not required but specified in de the documentation. It might be needed if more specific settings are added.

Resolves #299 

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x] I have followed the project's style guidelines by running the relevant scripts/\* tools.
- [x] I have rebased my branch onto the latest commit of the main branch.
- [x] I have squashed or reorganized my commits into logical units.
- [x] I have updated documentation.
