### PR TITLE
🐛(docs) remove TRASHBIN_CUTOFF_DAYS env var

### DIFF
--- a/helmfile/apps/docs/values.yaml.gotmpl
+++ b/helmfile/apps/docs/values.yaml.gotmpl
@@ -180,7 +180,6 @@ backend:
     STORAGES_STATICFILES_BACKEND: "django.contrib.staticfiles.storage.StaticFilesStorage"
     THEME_CUSTOMIZATION_CACHE_TIMEOUT: "86400"
     THEME_CUSTOMIZATION_FILE_PATH: ""
-    TRASHBIN_CUTOFF_DAYS: "30"
     USER_OIDC_ESSENTIAL_CLAIMS: ""
     Y_PROVIDER_API_BASE_URL: "http://docs-y-provider:443/api/"
     Y_PROVIDER_API_KEY: {{ .Values.application.docs.yProvider.key | quote }}


### PR DESCRIPTION
# Description

Temporary fix to make the removed items appear in the trashbin of Docs. When the upstream docs repo is fixed (a PR is made), we can add the TRASHBIN_CUTOFF_DAYS env var again.

Resolves #

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x] I have followed the project's style guidelines by running the relevant scripts/\* tools.
- [x] I have rebased my branch onto the latest commit of the main branch.
- [x] I have squashed or reorganized my commits into logical units.
- [x] I have updated documentation.
