### PR TITLE
PDB for docs fix and add configuration option

### DIFF
--- a/helmfile/apps/docs/charts/docs/templates/backend-cronjob-list.yaml
+++ b/helmfile/apps/docs/charts/docs/templates/backend-cronjob-list.yaml
@@ -42,6 +42,7 @@ items:
               {{- $podLabels := include "common.tplvalues.merge" (dict "values" (list $.Values.backend.podLabels $.Values.commonLabels) "context" .) }}
               labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}
                 app.kubernetes.io/component: backend
+                app.kubernetes.io/workload-type: cronjob
             spec:
               {{- include "docs.imagePullSecrets" $ | nindent 14 }}
               serviceAccountName: {{ template "docs.serviceAccountName" $ }}

--- a/helmfile/apps/docs/charts/docs/templates/backend-deployment.yaml
+++ b/helmfile/apps/docs/charts/docs/templates/backend-deployment.yaml
@@ -32,6 +32,7 @@ spec:
       {{- end }}
       labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}
         app.kubernetes.io/component: backend
+        app.kubernetes.io/workload-type: deployment
     spec:
       {{- include "docs.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ template "docs.serviceAccountName" . }}

--- a/helmfile/apps/docs/charts/docs/templates/backend-job.yaml
+++ b/helmfile/apps/docs/charts/docs/templates/backend-job.yaml
@@ -30,6 +30,7 @@ spec:
       {{- $podLabels := include "common.tplvalues.merge" (dict "values" (list $.Values.backend.podLabels $.Values.commonLabels) "context" .) }}
       labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}
         app.kubernetes.io/component: backend
+        app.kubernetes.io/workload-type: job
     spec:
       {{- include "docs.imagePullSecrets" $ | nindent 6 }}
       serviceAccountName: {{ template "docs.serviceAccountName" $ }}

--- a/helmfile/apps/docs/charts/docs/templates/backend-pdb.yaml
+++ b/helmfile/apps/docs/charts/docs/templates/backend-pdb.yaml
@@ -25,4 +25,5 @@ spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: backend
+      app.kubernetes.io/workload-type: deployment
 {{- end }}

--- a/helmfile/apps/docs/values-nginx.yaml.gotmpl
+++ b/helmfile/apps/docs/values-nginx.yaml.gotmpl
@@ -468,7 +468,7 @@ initContainers: []
 pdb:
   ## @param pdb.create Created a PodDisruptionBudget
   ##
-  create: true
+  create: {{ .Values.pdb.docs.nginx.create }}
   ## @param pdb.minAvailable Min number of pods that must still be available after the eviction.
   ## You can specify an integer or a percentage by setting the value to a string representation of a percentage (eg. "50%"). It will be disabled if set to 0
   ##

--- a/helmfile/apps/docs/values.yaml.gotmpl
+++ b/helmfile/apps/docs/values.yaml.gotmpl
@@ -28,6 +28,7 @@ backend:
   containerSecurityContext: {{ .Values.security.default.containerSecurityContext | toYaml | nindent 4 }}
   runtimeClassName: {{ .Values.cluster.runtimeClassName | quote }}
   pdb:
+    create: {{ .Values.pdb.docs.backend.create }}
     maxUnavailable: 1
   autoscaling:
     hpa: {{ .Values.autoscaling.horizontal.docs.backend | toYaml | nindent 6 }}
@@ -387,6 +388,7 @@ frontend:
   containerSecurityContext: {{ .Values.security.default.containerSecurityContext | toYaml | nindent 4 }}
   runtimeClassName: {{ .Values.cluster.runtimeClassName | quote }}
   pdb:
+    create: {{ .Values.pdb.docs.frontend.create }}
     maxUnavailable: 1
   autoscaling:
     hpa: {{ .Values.autoscaling.horizontal.docs.frontend | toYaml | nindent 6 }}
@@ -406,6 +408,7 @@ yProvider:
   containerSecurityContext: {{ .Values.security.default.containerSecurityContext | toYaml | nindent 4 }}
   runtimeClassName: {{ .Values.cluster.runtimeClassName | quote }}
   pdb:
+    create: {{ .Values.pdb.docs.yProvider.create }}
     maxUnavailable: 1
   autoscaling:
     hpa: {{ .Values.autoscaling.horizontal.docs.yProvider | toYaml | nindent 6 }}

--- a/helmfile/environments/default/pdb.yaml.gotmpl
+++ b/helmfile/environments/default/pdb.yaml.gotmpl
@@ -1,0 +1,11 @@
+## here you can overwrite specific application PodDisruptionBudget settings
+pdb:
+  docs:
+    backend:
+      create: true
+    frontend:
+      create: true
+    yProvider:
+      create: true
+    nginx:
+      create: true


### PR DESCRIPTION
# Description

The PDB for docs also targets the jobs, causing a lot of noise (events). This fix adds workload labels to make PDR targetting more accurate without disrupting other dependencies. Also, added pdb.create to be configurable using a values file.

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [X] I have followed the project's style guidelines by running the relevant scripts/\* tools.
- [X] I have rebased my branch onto the latest commit of the main branch.
- [X] I have squashed or reorganized my commits into logical units.
- [X] I have updated documentation.
