### PR TITLE
✨(docs) add docspec service + DOCSPEC_API_URL for docx import (#432)

### DIFF
--- a/helmfile/apps/docs/charts/docs/templates/_helpers.tpl
+++ b/helmfile/apps/docs/charts/docs/templates/_helpers.tpl
@@ -25,6 +25,14 @@ Full name for frontend
 {{- end -}}
 
 {{/*
+Full name for docspec
+*/}}
+{{- define "docs.docspec.fullname" -}}
+{{ include "common.names.fullname" . }}-docspec
+{{- end -}}
+
+
+{{/*
 Full name for the yProvider
 */}}
 {{- define "docs.yProvider.fullname" -}}
@@ -43,6 +51,13 @@ Return the proper frontend image name
 */}}
 {{- define "docs.frontend.image" -}}
 {{ include "common.images.image" (dict "imageRoot" .Values.frontend.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper docspec image name
+*/}}
+{{- define "docs.docspec.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.docspec.image "global" .Values.global) }}
 {{- end -}}
 
 {{/*

--- a/helmfile/apps/docs/charts/docs/templates/backend-job.yaml
+++ b/helmfile/apps/docs/charts/docs/templates/backend-job.yaml
@@ -78,9 +78,6 @@ spec:
             {{- if $envVars }}
             {{- $envVars | indent 12 }}
             {{- end }}
-            {{- if and (eq $config.name "migrate") $.Values.backend.migrateDbCredentials }}
-            {{- include "docs.env.transformDict" $.Values.backend.migrateDbCredentials | indent 12 }}
-            {{- end }}
             {{- if $.Values.backend.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" $.Values.backend.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}

--- a/helmfile/apps/docs/charts/docs/templates/docspec-deployment.yaml
+++ b/helmfile/apps/docs/charts/docs/templates/docspec-deployment.yaml
@@ -1,0 +1,164 @@
+{{- /*
+
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ template "docs.docspec.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: docspec
+  {{- if or .Values.docspec.deploymentAnnotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" (dict "values" (list .Values.docspec.deploymentAnnotations .Values.commonAnnotations) "context" .) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.docspec.replicaCount }}
+  {{- if .Values.docspec.updateStrategy }}
+  strategy: {{- toYaml .Values.docspec.updateStrategy | nindent 4 }}
+  {{- end }}
+  {{- $podLabels := include "common.tplvalues.merge" (dict "values" (list .Values.docspec.podLabels .Values.commonLabels) "context" .) }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+      app.kubernetes.io/component: docspec
+  template:
+    metadata:
+      {{- if .Values.docspec.podAnnotations }}
+      annotations: {{- include "common.tplvalues.render" (dict "value" .Values.docspec.podAnnotations "context" $) | nindent 8 }}
+      {{- end }}
+      labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}
+        app.kubernetes.io/component: docspec
+    spec:
+      {{- include "docs.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ template "docs.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.docspec.automountServiceAccountToken }}
+      {{- if .Values.docspec.hostAliases }}
+      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.docspec.hostAliases "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.docspec.affinity }}
+      affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.docspec.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.docspec.podAffinityPreset "component" "docs" "customLabels" $podLabels "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.docspec.podAntiAffinityPreset "component" "docs" "customLabels" $podLabels "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.docspec.nodeAffinityPreset.type "key" .Values.docspec.nodeAffinityPreset.key "values" .Values.docspec.nodeAffinityPreset.values) | nindent 10 }}
+      {{- end }}
+      {{- if .Values.docspec.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.docspec.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.docspec.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.docspec.tolerations "context" .) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.docspec.priorityClassName }}
+      priorityClassName: {{ .Values.docspec.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.docspec.schedulerName }}
+      schedulerName: {{ .Values.docspec.schedulerName | quote }}
+      {{- end }}
+      {{- if .Values.docspec.runtimeClassName }}
+      runtimeClassName: {{ .Values.docspec.runtimeClassName | quote }}
+      {{- end }}
+      {{- if .Values.docspec.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.docspec.topologySpreadConstraints "context" .) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.docspec.podSecurityContext.enabled }}
+      securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.docspec.podSecurityContext "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.docspec.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.docspec.terminationGracePeriodSeconds }}
+      {{- end }}
+      initContainers:
+        {{- if and .Values.defaultInitContainers.volumePermissions.enabled .Values.persistence.enabled }}
+        {{- include "docs.defaultInitContainers.volumePermissions" (dict "context" . "component" "docspec") | nindent 8 }}
+        {{- end }}
+        {{- if .Values.docspec.initContainers }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.docspec.initContainers "context" $) | nindent 8 }}
+        {{- end }}
+      containers:
+        - name: {{ template "docs.docspec.fullname" . }}
+          image: {{ template "docs.docspec.image" . }}
+          imagePullPolicy: {{ .Values.docspec.image.pullPolicy }}
+          {{- if .Values.docspec.containerSecurityContext.enabled }}
+          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.docspec.containerSecurityContext "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.diagnosticMode.enabled }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
+          {{- else if .Values.docspec.command }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.docspec.command "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.diagnosticMode.enabled }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
+          {{- else if .Values.docspec.args }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.docspec.args "context" $) | nindent 12 }}
+          {{- end }}
+          env:
+            {{- if .Values.docspec.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.docspec.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- if .Values.docspec.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.docspec.extraEnvVarsCM "context" $) }}
+            {{- end }}
+            {{- if .Values.docspec.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.docspec.extraEnvVarsSecret "context" $) }}
+            {{- end }}
+          {{- if .Values.docspec.resources }}
+          resources: {{- toYaml .Values.docspec.resources | nindent 12 }}
+          {{- else if ne .Values.docspec.resourcesPreset "none" }}
+          resources: {{- include "common.resources.preset" (dict "type" .Values.docspec.resourcesPreset) | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.docspec.containerPorts.http }}
+            {{- if .Values.docspec.extraContainerPorts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.docspec.extraContainerPorts "context" $) | nindent 12 }}
+            {{- end }}
+          {{- if not .Values.diagnosticMode.enabled }}
+          {{- if .Values.docspec.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.docspec.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.docspec.livenessProbe.enabled }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.docspec.livenessProbe "enabled") "context" $) | nindent 12 }}
+            httpGet:
+              path: /health
+              port: {{ .Values.docspec.containerPorts.http }}
+          {{- end }}
+          {{- if .Values.docspec.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.docspec.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.docspec.readinessProbe.enabled }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.docspec.readinessProbe "enabled") "context" $) | nindent 12 }}
+            httpGet:
+              path: /health
+              port: {{ .Values.docspec.containerPorts.http }}
+          {{- end }}
+          {{- if .Values.docspec.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.docspec.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.docspec.startupProbe.enabled }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.docspec.startupProbe "enabled") "context" $) | nindent 12 }}
+            httpGet:
+              path: /
+              port: {{ .Values.docspec.containerPorts.http }}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.docspec.lifecycleHooks }}
+          lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.docspec.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+          {{- if .Values.docspec.extraVolumeMounts }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.docspec.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
+        {{- if .Values.docspec.sidecars }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.docspec.sidecars "context" $) | nindent 8 }}
+        {{- end }}
+      volumes:
+        - name: empty-dir
+          emptyDir: {}
+        {{- if .Values.docspec.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.docspec.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}

--- a/helmfile/apps/docs/charts/docs/templates/docspec-service.yaml
+++ b/helmfile/apps/docs/charts/docs/templates/docspec-service.yaml
@@ -1,0 +1,54 @@
+{{- /*
+
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "docs.docspec.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: docspec
+  {{- if or .Values.docspec.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" (dict "values" (list .Values.docspec.service.annotations .Values.commonAnnotations) "context" .) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.docspec.service.type }}
+  {{- if and .Values.docspec.service.clusterIP (eq .Values.docspec.service.type "ClusterIP") }}
+  clusterIP: {{ .Values.docspec.service.clusterIP }}
+  {{- end }}
+  {{- if .Values.docspec.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.docspec.service.sessionAffinity }}
+  {{- end }}
+  {{- if .Values.docspec.service.sessionAffinityConfig }}
+  sessionAffinityConfig: {{- include "common.tplvalues.render" (dict "value" .Values.docspec.service.sessionAffinityConfig "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if or (eq .Values.docspec.service.type "LoadBalancer") (eq .Values.docspec.service.type "NodePort") }}
+  externalTrafficPolicy: {{ .Values.docspec.service.externalTrafficPolicy | quote }}
+  {{- end }}
+  {{- if and (eq .Values.docspec.service.type "LoadBalancer") (not (empty .Values.docspec.service.loadBalancerSourceRanges)) }}
+  loadBalancerSourceRanges: {{ .Values.docspec.service.loadBalancerSourceRanges }}
+  {{- end }}
+  {{- if and (eq .Values.docspec.service.type "LoadBalancer") (not (empty .Values.docspec.service.loadBalancerIP)) }}
+  loadBalancerIP: {{ .Values.docspec.service.loadBalancerIP }}
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.docspec.service.ports.http }}
+      {{- if not (eq .Values.docspec.service.ports.http .Values.docspec.containerPorts.http) }}
+      targetPort: {{ .Values.docspec.containerPorts.http }}
+      {{- end }}
+      protocol: TCP
+      {{- if and (or (eq .Values.docspec.service.type "NodePort") (eq .Values.docspec.service.type "LoadBalancer")) (not (empty .Values.docspec.service.nodePorts.http)) }}
+      nodePort: {{ .Values.docspec.service.nodePorts.http }}
+      {{- else if eq .Values.docspec.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
+    {{- if .Values.docspec.service.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.docspec.service.extraPorts "context" $) | nindent 4 }}
+    {{- end }}
+  {{- $podLabels := include "common.tplvalues.merge" (dict "values" (list .Values.docspec.podLabels .Values.commonLabels) "context" .) | fromYaml }}
+  selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: docspec

--- a/helmfile/apps/docs/charts/docs/values.yaml
+++ b/helmfile/apps/docs/charts/docs/values.yaml
@@ -1488,6 +1488,476 @@ frontend:
     serviceWorkerDeactivated: false
     ## @param frontend.configuration.publishAsMit Removes packages whose licences are incompatible with the MIT licence (xl-docx-exporter: GPL, xl-pdf-exporter: GPL, xl-multi-column: GPL)
     publishAsMit: true
+
+## docspec
+##
+docspec:
+  ## Impress frontend image
+  ## ref: https://hub.docker.com/r/lasuite/impress-frontend/tags
+  ## @param frontend.image.registry Impress frontend image registry
+  ## @param frontend.image.repository Impress frontend image repository
+  ## @skip frontend.image.tag Impress frontend image tag (immutable tags are recommended)
+  ## @param frontend.image.digest Impress frontend image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)
+  ## @param frontend.image.pullPolicy Impress frontend image pull policy
+  ## @param frontend.image.pullSecrets Impress frontend image pull secrets
+  ##
+  image:
+    registry: ghcr.io
+    repository: docspecio/api
+    tag: "2.6.3"
+    digest: ""
+    ## Specify a imagePullPolicy
+    ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
+    ##
+    pullPolicy: Always
+    ## Optionally specify an array of imagePullSecrets (secrets must be manually created in the namespace)
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## e.g:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
+  ## @param frontend.replicaCount Number of Impress frontend replicas to deploy
+  ##
+  replicaCount: 1
+  ## @param frontend.containerPorts.http Impress frontend HTTP container port
+  ##
+  containerPorts:
+    http: 4000
+  ## @param frontend.extraContainerPorts Optionally specify extra list of additional ports for Impress frontend containers
+  ## e.g:
+  ## extraContainerPorts:
+  ##   - name: myservice
+  ##     containerPort: 9090
+  ##
+  extraContainerPorts: []
+  ## Configure extra options for Impress frontend containers' liveness and readiness probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+  ## @param frontend.livenessProbe.enabled Enable livenessProbe on Impress frontend containers
+  ## @param frontend.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+  ## @param frontend.livenessProbe.periodSeconds Period seconds for livenessProbe
+  ## @param frontend.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+  ## @param frontend.livenessProbe.failureThreshold Failure threshold for livenessProbe
+  ## @param frontend.livenessProbe.successThreshold Success threshold for livenessProbe
+  ##
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+    successThreshold: 1
+  ## @param frontend.readinessProbe.enabled Enable readinessProbe on Impress frontend containers
+  ## @param frontend.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+  ## @param frontend.readinessProbe.periodSeconds Period seconds for readinessProbe
+  ## @param frontend.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+  ## @param frontend.readinessProbe.failureThreshold Failure threshold for readinessProbe
+  ## @param frontend.readinessProbe.successThreshold Success threshold for readinessProbe
+  ##
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+    successThreshold: 1
+  ## @param frontend.startupProbe.enabled Enable startupProbe on Impress frontend containers
+  ## @param frontend.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+  ## @param frontend.startupProbe.periodSeconds Period seconds for startupProbe
+  ## @param frontend.startupProbe.timeoutSeconds Timeout seconds for startupProbe
+  ## @param frontend.startupProbe.failureThreshold Failure threshold for startupProbe
+  ## @param frontend.startupProbe.successThreshold Success threshold for startupProbe
+  ##
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+    successThreshold: 1
+  ## @param frontend.customLivenessProbe Custom livenessProbe that overrides the default one
+  ##
+  customLivenessProbe: {}
+  ## @param frontend.customReadinessProbe Custom readinessProbe that overrides the default one
+  ##
+  customReadinessProbe: {}
+  ## @param frontend.customStartupProbe Custom startupProbe that overrides the default one
+  ##
+  customStartupProbe: {}
+  ## Impress frontend resource requests and limits
+  ## ref: http://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+  ## @param frontend.resourcesPreset Set Impress frontend container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if frontend.resources is set (frontend.resources is recommended for production).
+  ## More information: https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
+  ##
+  resourcesPreset: "nano"
+  ## @param frontend.resources Set Impress frontend container requests and limits for different resources like CPU or memory (essential for production workloads)
+  ## Example:
+  ## resources:
+  ##   requests:
+  ##     cpu: 2
+  ##     memory: 512Mi
+  ##   limits:
+  ##     cpu: 3
+  ##     memory: 1024Mi
+  ##
+  resources: {}
+  ## Configure Pods Security Context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  ## @param frontend.podSecurityContext.enabled Enable Impress frontend pods' Security Context
+  ## @param frontend.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy for Impress frontend pods
+  ## @param frontend.podSecurityContext.sysctls Set kernel settings using the sysctl interface for Impress frontend pods
+  ## @param frontend.podSecurityContext.supplementalGroups Set filesystem extra groups for Impress frontend pods
+  ## @param frontend.podSecurityContext.fsGroup Set fsGroup in Impress frontend pods' Security Context
+  ##
+  podSecurityContext:
+    enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
+    fsGroup: 1001
+  ## Configure Container Security Context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  ## @param frontend.containerSecurityContext.enabled Enabled Impress frontend container' Security Context
+  ## @param frontend.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in Impress frontend container
+  ## @param frontend.containerSecurityContext.runAsUser Set runAsUser in Impress frontend container' Security Context
+  ## @param frontend.containerSecurityContext.runAsGroup Set runAsGroup in Impress frontend container' Security Context
+  ## @param frontend.containerSecurityContext.runAsNonRoot Set runAsNonRoot in Impress frontend container' Security Context
+  ## @param frontend.containerSecurityContext.readOnlyRootFilesystem Set readOnlyRootFilesystem in Impress frontend container' Security Context
+  ## @param frontend.containerSecurityContext.privileged Set privileged in Impress frontend container' Security Context
+  ## @param frontend.containerSecurityContext.allowPrivilegeEscalation Set allowPrivilegeEscalation in Impress frontend container' Security Context
+  ## @param frontend.containerSecurityContext.capabilities.drop List of capabilities to be dropped in Impress frontend container
+  ## @param frontend.containerSecurityContext.seccompProfile.type Set seccomp profile in Impress frontend container
+  ##
+  containerSecurityContext:
+    enabled: true
+    seLinuxOptions: {}
+    runAsUser: 1001
+    runAsGroup: 1001
+    runAsNonRoot: true
+    readOnlyRootFilesystem: true
+    privileged: false
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+    seccompProfile:
+      type: "RuntimeDefault"
+  ## @param frontend.existingConfigmap The name of an existing ConfigMap with your custom configuration for Impress frontend
+  ##
+  existingConfigmap: ""
+  ## @param frontend.command Override default Impress frontend container command (useful when using custom images)
+  ##
+  command: []
+  ## @param frontend.args Override default Impress frontend container args (useful when using custom images)
+  ##
+  args: []
+  ## @param frontend.automountServiceAccountToken Mount Service Account token in Impress frontend pods
+  ##
+  automountServiceAccountToken: false
+  ## @param frontend.hostAliases Impress frontend pods host aliases
+  ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+  ##
+  hostAliases: []
+  ## @param frontend.daemonsetAnnotations Annotations for Impress frontend daemonset
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  daemonsetAnnotations: {}
+  ## @param frontend.deploymentAnnotations Annotations for Impress frontend deployment
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  deploymentAnnotations: {}
+  ## @param frontend.statefulsetAnnotations Annotations for Impress frontend statefulset
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  statefulsetAnnotations: {}
+  ## @param frontend.podLabels Extra labels for Impress frontend pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  ##
+  podLabels: {}
+  ## @param frontend.podAnnotations Annotations for Impress frontend pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
+  ## @param frontend.podAffinityPreset Pod affinity preset. Ignored if `frontend.affinity` is set. Allowed values: `soft` or `hard`
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ##
+  podAffinityPreset: ""
+  ## @param frontend.podAntiAffinityPreset Pod anti-affinity preset. Ignored if `frontend.affinity` is set. Allowed values: `soft` or `hard`
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ##
+  podAntiAffinityPreset: soft
+  ## Node frontend.affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+  ##
+  nodeAffinityPreset:
+    ## @param frontend.nodeAffinityPreset.type Node affinity preset type. Ignored if `frontend.affinity` is set. Allowed values: `soft` or `hard`
+    ##
+    type: ""
+    ## @param frontend.nodeAffinityPreset.key Node label key to match. Ignored if `frontend.affinity` is set
+    ##
+    key: ""
+    ## @param frontend.nodeAffinityPreset.values Node label values to match. Ignored if `frontend.affinity` is set
+    ## E.g.
+    ## values:
+    ##   - e2e-az1
+    ##   - e2e-az2
+    ##
+    values: []
+  ## @param frontend.affinity Affinity for Impress frontend pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## NOTE: `frontend.podAffinityPreset`, `frontend.podAntiAffinityPreset`, and `frontend.nodeAffinityPreset` will be ignored when it's set
+  ##
+  affinity: {}
+  ## @param frontend.nodeSelector Node labels for Impress frontend pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+  ##
+  nodeSelector: {}
+  ## @param frontend.tolerations Tolerations for Impress frontend pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+  ## ONLY FOR DEPLOYMENTS:
+  ## @param frontend.updateStrategy.type Impress frontend deployment strategy type
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+  ## ONLY FOR STATEFULSETS:
+  ## @param frontend.updateStrategy.type Impress frontend statefulset strategy type
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
+  ##
+  updateStrategy:
+    ## ONLY FOR DEPLOYMENTS:
+    ## Can be set to RollingUpdate or Recreate
+    ## ONLY FOR STATEFULSETS:
+    ## Can be set to RollingUpdate or OnDelete
+    ##
+    type: RollingUpdate
+  ## ONLY FOR STATEFULSETS:
+  ## @param frontend.podManagementPolicy Pod management policy for Impress frontend statefulset
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies
+  ##
+  podManagementPolicy: OrderedReady
+  ## @param frontend.priorityClassName Impress frontend pods' priorityClassName
+  ##
+  priorityClassName: ""
+  ## @param frontend.topologySpreadConstraints Topology Spread Constraints for Impress frontend pod assignment spread across your cluster among failure-domains
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
+  ##
+  topologySpreadConstraints: []
+  ## @param frontend.runtimeClassName Name of the runtime class name for meet pods
+  ## ref: https://kubernetes.io/docs/concepts/containers/runtime-class/#usage
+  ##
+  runtimeClassName: ""
+  ## @param frontend.schedulerName Name of the k8s scheduler (other than default) for Impress frontend pods
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  schedulerName: ""
+  ## @param frontend.terminationGracePeriodSeconds Seconds Impress frontend pods need to terminate gracefully
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
+  ##
+  terminationGracePeriodSeconds: ""
+  ## @param frontend.lifecycleHooks for Impress frontend containers to automate configuration before or after startup
+  ##
+  lifecycleHooks: {}
+  ## @param frontend.extraEnvVars Array with extra environment variables to add to Impress frontend containers
+  ## e.g:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: "bar"
+  ##
+  extraEnvVars: []
+  ## @param frontend.extraEnvVarsCM Name of existing ConfigMap containing extra env vars for Impress frontend containers
+  ##
+  extraEnvVarsCM: ""
+  ## @param frontend.extraEnvVarsSecret Name of existing Secret containing extra env vars for Impress frontend containers
+  ##
+  extraEnvVarsSecret: ""
+  ## @param frontend.extraVolumes Optionally specify extra list of additional volumes for the Impress frontend pods
+  ##
+  extraVolumes: []
+  ## @param frontend.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the Impress frontend containers
+  ##
+  extraVolumeMounts: []
+  ## @param frontend.sidecars Add additional sidecar containers to the Impress frontend pods
+  ## e.g:
+  ## sidecars:
+  ##   - name: your-image-name
+  ##     image: your-image
+  ##     imagePullPolicy: Always
+  ##     ports:
+  ##       - name: portname
+  ##         containerPort: 1234
+  ##
+  sidecars: []
+  ## @param frontend.initContainers Add additional init containers to the Impress frontend pods
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+  ## e.g:
+  ## initContainers:
+  ##  - name: your-image-name
+  ##    image: your-image
+  ##    imagePullPolicy: Always
+  ##    command: ['sh', '-c', 'echo "hello world"']
+  ##
+  initContainers: []
+  ## Pod Disruption Budget configuration
+  ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb
+  ## @param frontend.pdb.create Enable/disable a Pod Disruption Budget creation
+  ## @param frontend.pdb.minAvailable Minimum number/percentage of pods that should remain scheduled
+  ## @param frontend.pdb.maxUnavailable Maximum number/percentage of pods that may be made unavailable. Defaults to `1` if both `frontend.pdb.minAvailable` and `frontend.pdb.maxUnavailable` are empty.
+  ##
+  pdb:
+    create: true
+    minAvailable: ""
+    maxUnavailable: ""
+  ## Autoscaling configuration
+  ## ref: https://kubernetes.io/docs/concepts/workloads/autoscaling/
+  ##
+  autoscaling:
+    ## @param frontend.autoscaling.vpa.enabled Enable VPA for Impress frontend pods
+    ## @param frontend.autoscaling.vpa.annotations Annotations for VPA resource
+    ## @param frontend.autoscaling.vpa.controlledResources VPA List of resources that the vertical pod autoscaler can control. Defaults to cpu and memory
+    ## @param frontend.autoscaling.vpa.maxAllowed VPA Max allowed resources for the pod
+    ## @param frontend.autoscaling.vpa.minAllowed VPA Min allowed resources for the pod
+    ##
+    vpa:
+      enabled: false
+      annotations: {}
+      controlledResources: []
+      maxAllowed: {}
+      minAllowed: {}
+      ## @param frontend.autoscaling.vpa.updatePolicy.updateMode Autoscaling update policy
+      ## Specifies whether recommended updates are applied when a Pod is started and whether recommended updates are applied during the life of a Pod
+      ## Possible values are "Off", "Initial", "Recreate", and "Auto".
+      ##
+      updatePolicy:
+        updateMode: Auto
+    ## @param frontend.autoscaling.hpa.enabled Enable HPA for Impress frontend pods
+    ## @param frontend.autoscaling.hpa.minReplicas Minimum number of replicas
+    ## @param frontend.autoscaling.hpa.maxReplicas Maximum number of replicas
+    ## @param frontend.autoscaling.hpa.targetCPU Target CPU utilization percentage
+    ## @param frontend.autoscaling.hpa.targetMemory Target Memory utilization percentage
+    ##
+    hpa:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 3
+      targetCPU: 75
+      targetMemory: ""
+  ## Network Policies
+  ## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+  ##
+  networkPolicy:
+    ## @param frontend.networkPolicy.enabled Specifies whether a NetworkPolicy should be created
+    ##
+    enabled: true
+    ## @param frontend.networkPolicy.allowExternal Don't require server label for connections
+    ## The Policy model to apply. When set to false, only pods with the correct
+    ## server label will have network access to the ports server is listening
+    ## on. When true, server will accept connections from any source
+    ## (with the correct destination port).
+    ##
+    allowExternal: true
+    ## @param frontend.networkPolicy.allowExternalEgress Allow the pod to access any range of port and all destinations.
+    ##
+    allowExternalEgress: false
+    ## @param frontend.networkPolicy.addExternalClientAccess Allow access from pods with client label set to "true". Ignored if `networkPolicy.allowExternal` is true.
+    ##
+    addExternalClientAccess: false
+    ## @param frontend.networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolicy
+    ## e.g:
+    ## extraIngress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     from:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    extraIngress: []
+    ## @param frontend.networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy (ignored if allowExternalEgress=true)
+    ## e.g:
+    ## extraEgress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     to:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    ##
+    extraEgress: []
+    ## @param frontend.networkPolicy.ingressPodMatchLabels [object] Labels to match to allow traffic from other pods. Ignored if `networkPolicy.allowExternal` is true.
+    ## e.g:
+    ## ingressPodMatchLabels:
+    ##   my-client: "true"
+    #
+    ingressPodMatchLabels: {}
+    ## @param frontend.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces. Ignored if `networkPolicy.allowExternal` is true.
+    ## @param frontend.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces. Ignored if `networkPolicy.allowExternal` is true.
+    ##
+    ingressNSMatchLabels: {}
+    ingressNSPodMatchLabels: {}
+  ## Docs frontend service parameters
+  service:
+    ## @param frontend.service.type Impress frontend service type
+    ##
+    type: ClusterIP
+    ## @param frontend.service.ports.http Impress frontend service HTTP port
+    ##
+    ports:
+      http: 4000
+    ## Node ports to expose
+    ## @param frontend.service.nodePorts.http Node port for HTTP
+    ## NOTE: choose port between <30000-32767>
+    ##
+    nodePorts:
+      http: ""
+    ## @param frontend.service.clusterIP Impress frontend service Cluster IP
+    ## e.g.:
+    ## clusterIP: None
+    ##
+    clusterIP: ""
+    ## @param frontend.service.loadBalancerIP Impress frontend service Load Balancer IP
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
+    ##
+    loadBalancerIP: ""
+    ## @param frontend.service.loadBalancerSourceRanges Impress frontend service Load Balancer sources
+    ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    ## e.g:
+    ## loadBalancerSourceRanges:
+    ##   - 10.10.10.0/24
+    ##
+    loadBalancerSourceRanges: []
+    ## @param frontend.service.externalTrafficPolicy Impress frontend service external traffic policy
+    ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+    ##
+    externalTrafficPolicy: Cluster
+    ## @param frontend.service.annotations Additional custom annotations for Impress frontend service
+    ##
+    annotations: {}
+    ## @param frontend.service.extraPorts Extra ports to expose in Impress frontend service (normally used with the `sidecars` value)
+    ##
+    extraPorts: []
+    ## @param frontend.service.sessionAffinity Control where client requests go, to the same pod or round-robin
+    ## Values: ClientIP or None
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/
+    ##
+    sessionAffinity: None
+    ## @param frontend.service.sessionAffinityConfig Additional settings for the sessionAffinity
+    ## sessionAffinityConfig:
+    ##   clientIP:
+    ##     timeoutSeconds: 300
+    ##
+    sessionAffinityConfig: {}
+
+
 ## @section Docs y-provider Parameters
 ##
 yProvider:

--- a/helmfile/apps/docs/values.yaml.gotmpl
+++ b/helmfile/apps/docs/values.yaml.gotmpl
@@ -77,6 +77,14 @@ backend:
               matchLabels:
                 app.kubernetes.io/name: ollama
       {{- end }}
+      # Docspec connectivity
+      - ports:
+          - port: 4000
+            protocol: TCP
+        to:
+          - podSelector:
+              matchLabels:
+                app.kubernetes.io/name: docs-docspec
       # Allow https egress for keycloak connection and external AI
       - ports:
           - port: 443
@@ -111,7 +119,7 @@ backend:
     CONVERSION_API_CONTENT_FIELD: "content"
     CONVERSION_API_ENDPOINT: "convert"
     CONVERSION_API_SECURE: "false"
-    CONVERSION_API_TIMEOUT: "30"
+    DOCSPEC_API_URL: http://docs-docspec:4000/conversion
     CRISP_WEBSITE_ID: ""
     DOCUMENT_IMAGE_MAX_SIZE: "10485760"
     FRONTEND_CSS_URL: "https://static-{{ .Values.global.hostname.docs }}.{{ .Values.global.domain }}/iframe-hide.css"
@@ -397,6 +405,21 @@ frontend:
     vpa: {{ .Values.autoscaling.vertical.docs.frontend | toYaml | nindent 6 }}
   configuration:
     publishAsMit: {{ .Values.application.docs.frontend.publishAsMit }}
+
+docspec:
+  image:
+    registry: {{(coalesce .Values.container.docspec.registry .Values.container.default.registry) | quote }}
+    repository: {{ .Values.container.docspec.repository | quote }}
+    tag: {{ .Values.container.docspec.tag | quote }}
+  replicaCount: 1
+  resourcesPreset: {{ .Values.global.resourcesPreset | quote }}
+  resources: {{ .Values.resource.docs.docspec | toYaml | nindent 4 }}
+  podSecurityContext: {{ .Values.security.default.podSecurityContext | toYaml | nindent 4 }}
+  containerSecurityContext: {{ .Values.security.default.containerSecurityContext | toYaml | nindent 4 }}
+  runtimeClassName: {{ .Values.cluster.runtimeClassName | quote }}
+  pdb: {{ .Values.pdb.docs.docspec | toYaml | nindent 4 }}
+  autoscaling:
+    hpa: {{ .Values.autoscaling.horizontal.docs.docspec | toYaml | nindent 6 }}
 
 yProvider:
   image:

--- a/helmfile/environments/default/autoscaling.yaml.gotmpl
+++ b/helmfile/environments/default/autoscaling.yaml.gotmpl
@@ -93,6 +93,12 @@ autoscaling:
         maxReplicas: 3
         targetCPU: 80
         targetMemory: ""
+      docspec:
+        enabled: true
+        minReplicas: 1
+        maxReplicas: 3
+        targetCPU: 80
+        targetMemory: ""
       yProvider:
         # Disabled, see: https://github.com/MinBZK/mijn-bureau-infra/issues/219
         enabled: false

--- a/helmfile/environments/default/container.yaml.gotmpl
+++ b/helmfile/environments/default/container.yaml.gotmpl
@@ -135,6 +135,11 @@ container:
     repository: bitnamilegacy/nginx
     tag: 1.29.1
     imagePullSecret: ~
+  docspec:
+    imagePullSecret: ~
+    registry: "ghcr.io"
+    repository: "docspecio/api"
+    tag: "2.6.3"
   docs:
     imagePullSecret: ~
     registry: "registry-1.docker.io"

--- a/helmfile/environments/default/pdb.yaml.gotmpl
+++ b/helmfile/environments/default/pdb.yaml.gotmpl
@@ -59,6 +59,9 @@ pdb:
       # Disabled, see: https://github.com/MinBZK/mijn-bureau-infra/issues/219
       create: false
       maxUnavailable: 1
+    docspec:
+      create: true
+      maxUnavailable: 1
   bureaublad:
     backend:
       create: true

--- a/helmfile/environments/default/resource.yaml.gotmpl
+++ b/helmfile/environments/default/resource.yaml.gotmpl
@@ -69,6 +69,7 @@ resource:
     celery:
     frontend:
     yProvider:
+    docspec:
 
   bureaublad:
     backend:


### PR DESCRIPTION
# Description
Adds configuration and environment variable injection to support the new .docx import feature in the Docs component (requires DOCSPEC service).

- Added optional `docspec` block in `application.yaml.gotmpl` with `enabled` and `apiUrl` fields
- Conditionally set `DOCSPEC_API_URL` env var in Docs backend only when `application.docs.docspec.apiUrl` is provided
- Feature remains optional: docx import disabled if apiUrl is empty
- No DOCSPEC Helm chart added (none exists in repo yet); supports external or future in-cluster DOCSPEC

Resolves #432

## Checklist
- [ ] I have followed the project's style guidelines by running the relevant scripts/* tools.
- [x] I have rebased my branch onto the latest commit of the main branch.
- [x] I have squashed or reorganized my commits into logical units.
- [ ] I have updated documentation.
