### PR TITLE
🐛 (drive) Fix celery directory and healthcheck

### DIFF
--- a/helmfile/apps/drive/charts/drive/templates/deployment-backend-celery-beat.yaml
+++ b/helmfile/apps/drive/charts/drive/templates/deployment-backend-celery-beat.yaml
@@ -116,33 +116,24 @@ spec:
           {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.drive.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.drive.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.drive.celeryBeat.probes.liveness }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.drive.celeryBeat.probes.liveness "context" $) | nindent 12 }}
           {{- else if .Values.drive.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.drive.livenessProbe "enabled") "context" $) | nindent 12 }}
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - celery -A drive.celery_app inspect ping
           {{- end }}
           {{- if .Values.drive.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.drive.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.drive.celeryBeat.probes.readiness }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.drive.celeryBeat.probes.readiness "context" $) | nindent 12 }}
           {{- else if .Values.drive.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.drive.readinessProbe "enabled") "context" $) | nindent 12 }}
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - celery -A drive.celery_app inspect ping
           {{- end }}
           {{- if .Values.drive.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.drive.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.drive.celeryBeat.probes.startup }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.drive.celeryBeat.probes.startup "context" $) | nindent 12 }}
           {{- else if .Values.drive.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.drive.startupProbe "enabled") "context" $) | nindent 12 }}
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - celery -A drive.celery_app inspect ping
           {{- end }}
           {{- end }}
           {{- if .Values.drive.lifecycleHooks }}

--- a/helmfile/apps/drive/charts/drive/values.yaml
+++ b/helmfile/apps/drive/charts/drive/values.yaml
@@ -511,14 +511,24 @@ drive:
     replicas: 1
     command: []
     resources: {}
-    args: ["celery", "-A", "drive.celery_app", "beat", "-l", "INFO"]
+    args: ["celery", "-A", "drive.celery_app", "beat", "-l", "INFO", "--schedule=/tmp/celerybeat-schedule"]
     probes:
       liveness:
+        initialDelaySeconds: 30
+        periodSeconds: 10
+        timeoutSeconds: 2
+        failureThreshold: 3
+        successThreshold: 1
         exec:
-          command: ["/bin/sh", "-c", "celery -A drive.celery_app inspect ping"]
+          command: ["/bin/sh", "-c", "pgrep -f 'celery.*beat'"]
       readiness:
+        initialDelaySeconds: 30
+        periodSeconds: 10
+        timeoutSeconds: 2
+        failureThreshold: 3
+        successThreshold: 1
         exec:
-          command: ["/bin/sh", "-c", "celery -A drive.celery_app inspect ping"]
+          command: ["/bin/sh", "-c", "pgrep -f 'celery.*beat'"]
   secretKey: ""
   languageCode: "en-us"
   CSRFTrustedOrigins: ""


### PR DESCRIPTION
# Description

Celery was writing to a readoly directory, and the healthchecks were not implemented correctly. This meant that Drive-Celery did not ever get into the correct running state.

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x] I have followed the project's style guidelines by running the relevant scripts/\* tools.
- [x] I have rebased my branch onto the latest commit of the main branch.
- [x] I have squashed or reorganized my commits into logical units.
