### PR TITLE
🐛(settings) replace misused version to field to appropriate name path

### DIFF
--- a/helmfile/apps/bureaublad/values.yaml.gotmpl
+++ b/helmfile/apps/bureaublad/values.yaml.gotmpl
@@ -101,7 +101,7 @@ backend:
     {{- end }}
     {{- if .Values.ai.llm.endpoint.host }}
     AI_API_KEY: {{ .Values.ai.llm.apiKey | quote }}
-    AI_URL: {{ printf "http%s://%s:%d/%s" (ternary "s" "" .Values.ai.llm.endpoint.isSsl) .Values.ai.llm.endpoint.host .Values.ai.llm.endpoint.port .Values.ai.llm.endpoint.openApiVersion | quote }}
+    AI_URL: {{ printf "http%s://%s:%d/%s" (ternary "s" "" .Values.ai.llm.endpoint.isSsl) .Values.ai.llm.endpoint.host .Values.ai.llm.endpoint.port .Values.ai.llm.endpoint.path | quote }}
     AI_MODEL: {{ .Values.ai.llm.model | quote }}
     {{- end }}
     THEME_CSS_URL: ""

--- a/helmfile/apps/conversations/values-conversations.yaml.gotmpl
+++ b/helmfile/apps/conversations/values-conversations.yaml.gotmpl
@@ -114,14 +114,14 @@ authentication:
     client_secret: {{ .Values.authentication.client.conversations.client_secret | quote }}
 
 
-{{- $ollamaEnabled    := .Values.application.ollama.enabled }}
-{{- $aiModel          := .Values.ai.llm.model                 | default (ternary .Values.application.ollama.model "" $ollamaEnabled) }}
-{{- $aiHost           := .Values.ai.llm.endpoint.host         | default (ternary "ollama" "" $ollamaEnabled) }}
-{{- $aiPort           := .Values.ai.llm.endpoint.port         | default 11434 | int }}
-{{- $aiIsSsl          := ternary false .Values.ai.llm.endpoint.isSsl (and $ollamaEnabled (not .Values.ai.llm.endpoint.host)) }}
-{{- $aiOpenApiVersion := .Values.ai.llm.endpoint.openApiVersion | default "v1" }}
+{{- $ollamaEnabled := .Values.application.ollama.enabled }}
+{{- $aiModel       := .Values.ai.llm.model                | default (ternary .Values.application.ollama.model "" $ollamaEnabled) }}
+{{- $aiHost        := .Values.ai.llm.endpoint.host        | default (ternary "ollama" "" $ollamaEnabled) }}
+{{- $aiPort        := .Values.ai.llm.endpoint.port        | default 11434 | int }}
+{{- $aiIsSsl       := ternary false .Values.ai.llm.endpoint.isSsl (and $ollamaEnabled (not .Values.ai.llm.endpoint.host)) }}
+{{- $aiPath        := .Values.ai.llm.endpoint.path        | default "v1" }}
 
 ai:
   model: {{ $aiModel | quote }}
-  endpoint: {{ printf "http%s://%s:%d/%s" (ternary "s" "" $aiIsSsl) $aiHost $aiPort $aiOpenApiVersion | quote }}
+  endpoint: {{ printf "http%s://%s:%d/%s" (ternary "s" "" $aiIsSsl) $aiHost $aiPort $aiPath | quote }}
   apiKey: {{ .Values.ai.llm.apiKey | default "" | quote }}

--- a/helmfile/apps/docs/values.yaml.gotmpl
+++ b/helmfile/apps/docs/values.yaml.gotmpl
@@ -105,7 +105,7 @@ backend:
     {{- if .Values.ai.llm.endpoint.host }}
     AI_ALLOW_REACH_FROM: "authenticated"
     AI_API_KEY: {{ .Values.ai.llm.apiKey | quote }}
-    AI_BASE_URL: {{ printf "http%s://%s:%d/%s" (ternary "s" "" .Values.ai.llm.endpoint.isSsl) .Values.ai.llm.endpoint.host .Values.ai.llm.endpoint.port .Values.ai.llm.endpoint.openApiVersion }}
+    AI_BASE_URL: {{ printf "http%s://%s:%d/%s" (ternary "s" "" .Values.ai.llm.endpoint.isSsl) .Values.ai.llm.endpoint.host .Values.ai.llm.endpoint.port .Values.ai.llm.endpoint.path }}
     AI_MODEL: {{ .Values.ai.llm.model | quote }}
     {{- end }}
     API_USERS_LIST_LIMIT: "5"

--- a/helmfile/apps/grist/values.yaml.gotmpl
+++ b/helmfile/apps/grist/values.yaml.gotmpl
@@ -31,7 +31,7 @@ pdb: {{ .Values.pdb.grist | toYaml | nindent 2 }}
 ai:
   enabled: true
 {{- if .Values.ai.llm.endpoint.host }}
-  endpoint: {{ printf "http%s://%s:%d/%s/chat/completions" (ternary "s" "" .Values.ai.llm.endpoint.isSsl) .Values.ai.llm.endpoint.host .Values.ai.llm.endpoint.port .Values.ai.llm.endpoint.openApiVersion | quote }}
+  endpoint: {{ printf "http%s://%s:%d/%s/chat/completions" (ternary "s" "" .Values.ai.llm.endpoint.isSsl) .Values.ai.llm.endpoint.host .Values.ai.llm.endpoint.port .Values.ai.llm.endpoint.path | quote }}
 {{- end }}
 {{- if .Values.ai.llm.model }}
   model: {{ .Values.ai.llm.model | quote }}

--- a/helmfile/bases/logic/ai.yaml.gotmpl
+++ b/helmfile/bases/logic/ai.yaml.gotmpl
@@ -8,7 +8,7 @@ ai:
     endpoint:
       host: ollama
       port: 11434
-      openApiVersion: "v1"
+      path: "v1"
       isSsl: false
       isInternal: true
     {{- end }}

--- a/helmfile/environments/default/ai.yaml.gotmpl
+++ b/helmfile/environments/default/ai.yaml.gotmpl
@@ -4,7 +4,7 @@ ai:
     endpoint:
       host: ~
       port: ~
-      openApiVersion: "v1"
+      path: "v1"
       isSsl: true
       isInternal: false
     apiKey: ~


### PR DESCRIPTION
Fix AI endpoint URL rendering and rename openApiVersion to path

Renames ai.llm.endpoint.openApiVersion → path to clearly communicate that this field accepts a full URL path (e.g. v2.1/projects/poc/openai-compatible/v1), not just a  version string

Fixes broken endpoint URLs like https://host/v1:443/v1 caused by operators putting the full path in host instead of path

Resolves #

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x] I have followed the project's style guidelines by running the relevant scripts/\* tools.
- [x] I have rebased my branch onto the latest commit of the main branch.
- [x] I have squashed or reorganized my commits into logical units.
- [x] I have updated documentation.
