### PR TITLE
🐛 (conversations) add tmpdir to conversations migrate job

### DIFF
--- a/helmfile/apps/conversations/charts/conversations/templates/job-migrate.yaml
+++ b/helmfile/apps/conversations/charts/conversations/templates/job-migrate.yaml
@@ -60,3 +60,9 @@ spec:
           args: {{- include "common.tplvalues.render" (dict "value" .Values.job.args "context" $) | nindent 10 }}
           resources:
             {{- toYaml .Values.job.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}


### PR DESCRIPTION
# Description

The manage.py check fails since no tmpdir is accessible, causing migrate to fail which also breaks backend.

```
    from .session import (
    ...<2 lines>...
    )
  File "/app/.venv/lib/python3.13/site-packages/dill/session.py", line 25, in <module>
    TEMPDIR = pathlib.PurePath(tempfile.gettempdir())
                               ~~~~~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.13/tempfile.py", line 315, in gettempdir
    return _os.fsdecode(_gettempdir())
                        ~~~~~~~~~~~^^
  File "/usr/local/lib/python3.13/tempfile.py", line 308, in _gettempdir
    tempdir = _get_default_tempdir()
  File "/usr/local/lib/python3.13/tempfile.py", line 223, in _get_default_tempdir
    raise FileNotFoundError(_errno.ENOENT,
                            "No usable temporary directory found in %s" %
                            dirlist)
FileNotFoundError: [Errno 2] No usable temporary directory found in ['/tmp', '/var/tmp', '/usr/tmp', '/app']

```

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x] I have rebased my branch onto the latest commit of the main branch.
- [x] I have squashed or reorganized my commits into logical units.
