### PR TITLE
✅ (tests) Fix docspec container rule test

### DIFF
--- a/tests/container-rules.yaml
+++ b/tests/container-rules.yaml
@@ -71,6 +71,10 @@ container:
     registry: ""
     imagePullSecret: ""
 
+  docspec:
+    registry: ""
+    imagePullSecret: ""
+
   docs:
     registry: ""
     imagePullSecret: ""


### PR DESCRIPTION
An empty block was needed to make the override work correctly

# Description
An empty block was needed to make the override work correctly

## Before
```
================================================================================
❌ FAILED: container-rules
================================================================================
Running policy: test_container_imagepullsecret_propagation.rego
Running policy: test_container_registry_propagatio_init.rego
Running policy: test_container_registry_propagation.rego
FAIL - /tmp/tmp.NRT46CfBXQ/output/helmfile-child.yaml-3dbd375a-docs/docs/templates/docspec-deployment.yaml - main - Container 'docs-docspec' in Deployment 'docs-docspec' does not use test registry 'test-registr
y.example.com' in image 'ghcr.io/docspecio/api:2.6.3' (propagation failed)

311 tests, 310 passed, 0 warnings, 1 failure, 0 exceptions
FAILED: Policy test failed for file: /root/workspace/conversations-migrate-fix/tests/container-rules.yaml
policy_file: /root/workspace/conversations-migrate-fix/tests/container-rules/test_container_registry_propagation.rego
```

## After
```
================================================================================
✅ PASSED: container-rules
================================================================================
Running policy: test_container_imagepullsecret_propagation.rego
Running policy: test_container_registry_propagatio_init.rego
Running policy: test_container_registry_propagation.rego
================================================================================
```