### PR TITLE
🐛 (docs) Fix attachment serving

### DIFF
--- a/helmfile/apps/docs/helmfile-child.yaml.gotmpl
+++ b/helmfile/apps/docs/helmfile-child.yaml.gotmpl
@@ -53,7 +53,7 @@ releases:
     {{- if .Values.application.docs.namespace }}
     namespace: {{ .Values.application.docs.namespace }}
     {{- end }}
-    installed: {{ and .Values.application.docs.enabled (eq .Values.cluster.ingress.type "haproxy-openshift") | toYaml }}
+    installed: {{ .Values.application.docs.enabled | toYaml }}
     needs:
       - {{ if .Values.application.docs.namespace }}{{ .Values.application.docs.namespace }}/{{ end }}docs
     values:


### PR DESCRIPTION
# Description

The docs nginx container did not get deployed on a non-openshift setup, but it is needed to embed images and other files.