### PR TITLE
🐛 (meet) Enable usage of local livekit

### DIFF
--- a/helmfile/apps/meet/values.yaml.gotmpl
+++ b/helmfile/apps/meet/values.yaml.gotmpl
@@ -85,9 +85,16 @@ ingress:
     {{- end }}
 
 externalLivekit:
+  {{- if .Values.application.livekit.enabled }}
+  {{- $keyName := .Values.application.livekit.keys | keys | first }}
+  apiKey: {{ coalesce .Values.livekit.meet.apiKey $keyName | quote }}
+  apiSecret: {{ coalesce .Values.livekit.meet.apiSecret (index .Values.application.livekit.keys $keyName) | quote }}
+  apiUrl: {{ coalesce .Values.livekit.meet.apiURL (printf "https://%s.%s" .Values.global.hostname.livekit .Values.global.domain) | quote }}
+  {{- else }}
   apiKey: {{ .Values.livekit.meet.apiKey | quote }}
   apiSecret: {{ .Values.livekit.meet.apiSecret | quote }}
   apiUrl: {{ .Values.livekit.meet.apiURL | quote }}
+  {{- end }}
 
 externalRedis:
   host: {{ .Values.cache.meet.host | quote }}

--- a/helmfile/bases/logic/livekit.yaml.gotmpl
+++ b/helmfile/bases/logic/livekit.yaml.gotmpl
@@ -2,9 +2,9 @@
 livekit:
   meet:
     {{- if not .Values.livekit.meet.apiURL }}
-    {{- $first := index .Values.application.livekit.keys 0 }}
-    apiKey: {{ $first.name| quote }}
-    apiSecret: {{ $first.value | quote }}
-    apiURL: "https://livekit.{{ .Values.application.livekit.namespace }}.svc.{{ .Values.cluster.networking.domain }}
+    {{- $keyName := .Values.application.livekit.keys | keys | first }}
+    apiKey: {{ $keyName | quote }}
+    apiSecret: {{ index .Values.application.livekit.keys $keyName | quote }}
+    apiURL: "https://{{ .Values.global.hostname.livekit }}.{{ .Values.global.domain }}"
     {{- end }}
 {{- end }}


### PR DESCRIPTION
# Description

If we want to use mijnbureau's own livekit instance, this did not work in the current setup. 

This PR uses the local meet instance if it enabled, and falls back to user-configurable livekit settings. 