### PR TITLE
🐛 (bureaublad) Hide disabled components

### DIFF
--- a/helmfile/apps/bureaublad/values.yaml.gotmpl
+++ b/helmfile/apps/bureaublad/values.yaml.gotmpl
@@ -78,12 +78,24 @@ backend:
     OIDC_EMAIL_CLAIM: {{ .Values.authentication.oidc.claims.email | default "email" | quote }}
     OIDC_SCOPES: "openid email profile"
     OIDC_SIGNATURE_ALGORITM: "RS256"
+    {{- if .Values.application.nextcloud.enabled }}
     OCS_URL: {{ printf "http%s://%s.%s" $sslPostfix .Values.global.hostname.nextcloud .Values.global.domain }}
+    {{- end }}
+    {{- if .Values.application.drive.enabled }}
     DRIVE_URL: {{ printf "http%s://%s.%s" $sslPostfix .Values.global.hostname.drive .Values.global.domain | quote }}
+    {{- end }}
+    {{- if .Values.application.meet.enabled }}
     MEET_URL: {{ printf "http%s://%s.%s" $sslPostfix .Values.global.hostname.meet .Values.global.domain | quote }}
+    {{- end }}
+    {{- if .Values.application.grist.enabled }}
     GRIST_URL: {{ printf "http%s://%s.%s" $sslPostfix .Values.global.hostname.grist .Values.global.domain | quote }}
+    {{- end }}
+    {{- if .Values.application.conversations.enabled }}
     CONVERSATION_URL: {{ printf "http%s://%s.%s" $sslPostfix .Values.global.hostname.conversations .Values.global.domain | quote }}
+    {{- end }}
+    {{- if .Values.application.docs.enabled }}
     DOCS_URL: {{ printf "http%s://%s.%s" $sslPostfix .Values.global.hostname.docs .Values.global.domain | quote }}
+    {{- end }}
     {{- if .Values.application.element.enabled }}
     MATRIX_URL: {{ printf "http%s://%s.%s" $sslPostfix .Values.global.hostname.element .Values.global.domain | quote }}
     {{- end }}


### PR DESCRIPTION
# Description

An application that was disabled in helm would still show up in bureaublad and result in a broken link.
I just copied the logic that was already there for matrix. Tested by disabling nextcloud

## Checklist

- [x] I have followed the project's style guidelines by running the relevant scripts/\* tools.
- [x] I have rebased my branch onto the latest commit of the main branch.
- [x] I have squashed or reorganized my commits into logical units.