### PR TITLE
(docs) Fix table layout of tools

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -45,7 +45,7 @@ We are actively expanding the suite with plans to include:
 MijnBureau currently includes the following key components:
 
 | Feature            | Functional Component | Component Version                                                                   | Upstream Documentation                                                               | LICENSE    |
-| ------------------ | -------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | ---------- | --- |
+| ------------------ | -------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | ---------- |
 | Identity Provider  | Keycloak             | [26.3.3](https://github.com/keycloak/keycloak/releases/tag/26.3.3)                  | [documentation](https://www.keycloak.org/documentation)                              | Apache-2.0 |
 | Chat               | Element Synapse      | [v1.147.1](https://github.com/element-hq/synapse/releases/tag/v1.147.1)             | [documentation](https://element-hq.github.io/synapse/latest/)                        | AGPL-3.0   |
 | Chat UI            | Element Web          | [v1.12.10](https://github.com/element-hq/element-web/releases/tag/v1.12.10)         | [documentation](https://element.io/)                                                 | AGPL-3.0   |
@@ -57,7 +57,7 @@ MijnBureau currently includes the following key components:
 | Office             | Collabora            | [v25.04.9.1.1](https://github.com/CollaboraOnline/online/releases/tag/cp-25.04.9-1) | [documentation](https://sdk.collaboraonline.com/docs/installation/index.html)        | MPL-2.0    |
 | Video backend      | Livekit              | [v1.9.11](https://github.com/livekit/livekit/releases/tag/v1.9.11)                  | [documentation](https://livekit.io/)                                                 | Apache-2.0 |
 | AI Assistent       | Conversations        | [v0.0.13](https://github.com/suitenumerique/conversations/releases/tag/v0.0.13)     | [documentation](https://github.com/suitenumerique/conversations/blob/main/README.md) | MIT        |
-| Video conferencing | Meet                 | [v1.8.0](https://github.com/suitenumerique/meet/releases/tag/v1.8.0)                | [documentation](https://github.com/suitenumerique/meet/tree/main/docs)               | MIT        |     |
+| Video conferencing | Meet                 | [v1.8.0](https://github.com/suitenumerique/meet/releases/tag/v1.8.0)                | [documentation](https://github.com/suitenumerique/meet/tree/main/docs)               | MIT        |
 | Bureaublad         | Startpage            | [v0.5.4](https://github.com/MinBZK/bureaublad/releases/tag/v0.5.4)                  | [documentation](https://github.com/MinBZK/bureaublad)                                | EUPL-1.2   |
 | File sharing       | Drive                | [v0.13.0](https://github.com/suitenumerique/drive/releases/tag/v0.13.0)             | [documentation](https://github.com/suitenumerique/drive/blob/main/README.md)         | MIT        |
 | Antivirus Toolkit  | ClamAV               | [v1.5.1](https://github.com/Cisco-Talos/clamav/releases/tag/clamav-1.5.1)           | [documentation](https://docs.clamav.net/)                                            | GPLv2      |


### PR DESCRIPTION
# Description

There's some formatting issues with the table at https://minbzk.github.io/mijn-bureau-infra/docs/intro, see:

<img width="1145" height="547" alt="image" src="https://github.com/user-attachments/assets/33621f28-f62d-4ea7-bb80-707dee0ae709" />

This PR fixes it :sparkles: 

<img width="1181" height="901" alt="image" src="https://github.com/user-attachments/assets/20351f5c-11b8-4efe-9044-fba69bb697d5" />

I assume this PR doesn't need a ticket to reference to.

Resolves #

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [ ] I have followed the project's style guidelines by running the relevant scripts/\* tools.
- [ ] I have rebased my branch onto the latest commit of the main branch.
- [x] I have squashed or reorganized my commits into logical units.
- [x] I have updated documentation.
