### PR TITLE
Add observability

### DIFF
--- a/docs/docs/observability/metrics.md
+++ b/docs/docs/observability/metrics.md
@@ -21,3 +21,15 @@ podMonitor:
 ```
 
 For more details about these monitors, refer to the Prometheus Operator documentation.
+
+## Prometheus namespace
+
+Per-app `NetworkPolicy` ingress rules grant scrape access only to pods in the namespace hosting your Prometheus installation. The default is `monitoring`; override this if you installed `kube-prometheus-stack` (or any other Prometheus) elsewhere:
+
+```yaml
+metric:
+  enabled: true
+  namespace: observability # defaults to "monitoring"
+```
+
+Setting this updates every app's `NetworkPolicy` ingress rules and the Nextcloud exporter's dedicated policy in one place.

--- a/helmfile/apps/conversations/values-postgresql.yaml.gotmpl
+++ b/helmfile/apps/conversations/values-postgresql.yaml.gotmpl
@@ -694,6 +694,15 @@ primary:
               matchLabels:
                 app.kubernetes.io/name: conversations
                 app.kubernetes.io/component: conversations-migrate
+      {{- if .Values.metric.enabled }}
+      - ports:
+          - port: 9187
+            protocol: TCP
+        from:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: {{ .Values.metric.namespace }}
+      {{- end }}
     ## @param primary.networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
     ## e.g:
     ## extraEgress:

--- a/helmfile/apps/docs/values-minio.yaml.gotmpl
+++ b/helmfile/apps/docs/values-minio.yaml.gotmpl
@@ -775,6 +775,15 @@ networkPolicy:
         - podSelector:
             matchLabels:
               app.kubernetes.io/instance: docs-nginx
+    {{- if .Values.metric.enabled }}
+    - ports:
+        - port: {{ .Values.objectstore.docs.port }}
+          protocol: TCP
+      from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.metric.namespace }}
+    {{- end }}
   ## @param networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
   ## e.g:
   ## extraEgress:

--- a/helmfile/apps/docs/values-postgresql.yaml.gotmpl
+++ b/helmfile/apps/docs/values-postgresql.yaml.gotmpl
@@ -686,6 +686,15 @@ primary:
           - podSelector:
               matchLabels:
                 app.kubernetes.io/name: docs
+      {{- if .Values.metric.enabled }}
+      - ports:
+          - port: 9187
+            protocol: TCP
+        from:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: {{ .Values.metric.namespace }}
+      {{- end }}
     ## @param primary.networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
     ## e.g:
     ## extraEgress:

--- a/helmfile/apps/drive/values-minio.yaml.gotmpl
+++ b/helmfile/apps/drive/values-minio.yaml.gotmpl
@@ -784,8 +784,15 @@ networkPolicy:
       #   - podSelector:
       #       matchLabels:
       #         app.kubernetes.io/instance: drive-nginx
-
-
+    {{- if .Values.metric.enabled }}
+    - ports:
+        - port: {{ .Values.objectstore.drive.port }}
+          protocol: TCP
+      from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.metric.namespace }}
+    {{- end }}
   ## @param networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
   ## e.g:
   ## extraEgress:

--- a/helmfile/apps/drive/values-postgresql.yaml.gotmpl
+++ b/helmfile/apps/drive/values-postgresql.yaml.gotmpl
@@ -700,6 +700,15 @@ primary:
           - podSelector:
               matchLabels:
                 app.kubernetes.io/component: drive-wopi
+      {{- if .Values.metric.enabled }}
+      - ports:
+          - port: 9187
+            protocol: TCP
+        from:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: {{ .Values.metric.namespace }}
+      {{- end }}
     ## @param primary.networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
     ## e.g:
     ## extraEgress:

--- a/helmfile/apps/element/charts/synapse/templates/master/metrics-service.yaml
+++ b/helmfile/apps/element/charts/synapse/templates/master/metrics-service.yaml
@@ -1,0 +1,31 @@
+{{- /*
+
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.master.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ printf "%s-metrics" (include "synapse.master.fullname" .) }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" .) | nindent 4 }}
+    app.kubernetes.io/component: metrics
+  {{- if or .Values.master.metrics.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" (dict "values" (list .Values.master.metrics.service.annotations .Values.commonAnnotations) "context" .) }}
+  annotations: {{- include "common.tplvalues.render" (dict "value" $annotations "context" .) | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: tcp-metrics
+      port: {{ .Values.master.metrics.service.ports.metrics }}
+      protocol: TCP
+      targetPort: tcp-metrics
+    {{- if .Values.master.metrics.service.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.master.metrics.service.extraPorts "context" .) | nindent 4 }}
+    {{- end }}
+  {{- $podLabels := include "common.tplvalues.merge" (dict "values" (list .Values.master.podLabels .Values.commonLabels) "context" .) | fromYaml }}
+  selector: {{- include "common.labels.matchLabels" (dict "customLabels" $podLabels "context" .) | nindent 4 }}
+    app.kubernetes.io/component: master
+{{- end }}

--- a/helmfile/apps/element/charts/synapse/templates/master/servicemonitor.yaml
+++ b/helmfile/apps/element/charts/synapse/templates/master/servicemonitor.yaml
@@ -20,12 +20,13 @@ spec:
   jobLabel: {{ .Values.master.metrics.serviceMonitor.jobLabel | quote }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 6 }}
+      app.kubernetes.io/component: metrics
       {{- if .Values.master.metrics.serviceMonitor.selector }}
       {{- include "common.tplvalues.render" (dict "value" .Values.master.metrics.serviceMonitor.selector "context" $) | nindent 6 }}
       {{- end }}
   endpoints:
     - port: tcp-metrics
-      path: "/metrics"
+      path: {{ .Values.master.metrics.serviceMonitor.path | default "/_synapse/metrics" | quote }}
       {{- if .Values.master.metrics.serviceMonitor.tlsConfig }}
       scheme: https
       tlsConfig: {{- include "common.tplvalues.render" ( dict "value" .Values.master.metrics.serviceMonitor.tlsConfig "context" $) | nindent 8 }}

--- a/helmfile/apps/element/charts/synapse/values.yaml
+++ b/helmfile/apps/element/charts/synapse/values.yaml
@@ -587,12 +587,28 @@ master:
     ## @param master.metrics.enabled Enable the export of Prometheus metrics
     ##
     enabled: false
+    ## Metrics service parameters
+    ##
+    service:
+      ## @param master.metrics.service.ports.metrics Metrics service port
+      ##
+      ports:
+        metrics: 9090
+      ## @param master.metrics.service.annotations Annotations for the metrics service
+      ##
+      annotations: {}
+      ## @param master.metrics.service.extraPorts Extra ports for the metrics service
+      ##
+      extraPorts: []
     ## Prometheus Operator ServiceMonitor configuration
     ##
     serviceMonitor:
       ## @param master.metrics.serviceMonitor.enabled if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)
       ##
       enabled: false
+      ## @param master.metrics.serviceMonitor.path HTTP path Prometheus scrapes for metrics. Synapse serves metrics at /_synapse/metrics, not /metrics.
+      ##
+      path: "/_synapse/metrics"
       ## @param master.metrics.serviceMonitor.namespace Namespace in which Prometheus is running
       ##
       namespace: ""

--- a/helmfile/apps/element/values-postgresql.yaml.gotmpl
+++ b/helmfile/apps/element/values-postgresql.yaml.gotmpl
@@ -687,6 +687,15 @@ primary:
           - podSelector:
               matchLabels:
                 app.kubernetes.io/name: synapse
+      {{- if .Values.metric.enabled }}
+      - ports:
+          - port: 9187
+            protocol: TCP
+        from:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: {{ .Values.metric.namespace }}
+      {{- end }}
     ## @param primary.networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
     ## e.g:
     ## extraEgress:

--- a/helmfile/apps/element/values-synapse.yaml.gotmpl
+++ b/helmfile/apps/element/values-synapse.yaml.gotmpl
@@ -7,6 +7,10 @@
   $hostName is the hostname the server is available at
   $clientHostName is the host the client is running on
 */ -}}
+{{- /* Single source of truth for Synapse's Prometheus metrics port.
+       Drives both the chart's master.metrics.containerPort override (below)
+       and the network-policy ingress rule. */ -}}
+{{- $metricsPort := 9090 -}}
 {{- $serverName := .Values.global.matrixDomain | default (printf "%s.%s" .Values.global.hostname.synapse .Values.global.domain) -}}
 {{- $hostName := printf "%s.%s" .Values.global.hostname.synapse .Values.global.domain -}}
 {{- $clientHostName := printf "%s.%s" .Values.global.hostname.element .Values.global.domain -}}
@@ -54,6 +58,18 @@ master:
       - ports:
           - port: 8448
             protocol: TCP
+      {{- if .Values.metric.enabled }}
+      # Allow Prometheus to scrape metrics. Port is pinned to the chart's
+      # master.containerPorts.metrics (charts/synapse/values.yaml); change
+      # both together.
+      - from:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: {{ .Values.metric.namespace }}
+        ports:
+          - port: {{ $metricsPort }}
+            protocol: TCP
+      {{- end }}
     extraEgress:
       # Allow https egress for keycloak connection
       - ports:
@@ -80,6 +96,17 @@ master:
       {{- end }}
   podSecurityContext: {{ .Values.security.default.podSecurityContext | toYaml | nindent 4 }}
   containerSecurityContext: {{ .Values.security.default.containerSecurityContext | toYaml | nindent 4 }}
+  # Pin metrics container port so the chart's containerPort, the metrics
+  # Service, and the network-policy ingress rule above cannot drift apart.
+  containerPorts:
+    metrics: {{ $metricsPort }}
+  metrics:
+    enabled: {{ .Values.metric.enabled | default false }}
+    service:
+      ports:
+        metrics: {{ $metricsPort }}
+    serviceMonitor:
+      enabled: {{ .Values.metric.serviceMonitor.enabled | default false }}
 
 # TODO replication is not functional, see https://github.com/MinBZK/mijn-bureau-infra/issues/8
 worker:

--- a/helmfile/apps/grist/charts/grist/templates/deployment.yaml
+++ b/helmfile/apps/grist/charts/grist/templates/deployment.yaml
@@ -229,6 +229,10 @@ spec:
             - name: APP_STATIC_INCLUDE_CUSTOM_CSS
               value: "true"
             {{- end }}
+            {{- if .Values.metrics.enabled }}
+            - name: GRIST_PROMCLIENT_PORT
+              value: {{ .Values.containerPorts.metrics | quote }}
+            {{- end }}
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
@@ -249,6 +253,10 @@ spec:
           ports:
             - name: http
               containerPort: {{ .Values.containerPorts.http }}
+            {{- if .Values.metrics.enabled }}
+            - name: tcp-metrics
+              containerPort: {{ .Values.containerPorts.metrics }}
+            {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}

--- a/helmfile/apps/grist/charts/grist/templates/metrics-service.yaml
+++ b/helmfile/apps/grist/charts/grist/templates/metrics-service.yaml
@@ -1,0 +1,31 @@
+{{- /*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ printf "%s-metrics" (include "common.names.fullname" .) }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" .) | nindent 4 }}
+    app.kubernetes.io/component: metrics
+  {{- if or .Values.metrics.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" (dict "values" (list .Values.metrics.service.annotations .Values.commonAnnotations) "context" .) }}
+  annotations: {{- include "common.tplvalues.render" (dict "value" $annotations "context" .) | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: tcp-metrics
+      port: {{ .Values.metrics.service.ports.metrics }}
+      protocol: TCP
+      targetPort: tcp-metrics
+    {{- if .Values.metrics.service.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.metrics.service.extraPorts "context" .) | nindent 4 }}
+    {{- end }}
+  {{- $podLabels := include "common.tplvalues.merge" (dict "values" (list .Values.podLabels .Values.commonLabels) "context" .) | fromYaml }}
+  selector: {{- include "common.labels.matchLabels" (dict "customLabels" $podLabels "context" .) | nindent 4 }}
+    app.kubernetes.io/component: grist
+{{- end }}

--- a/helmfile/apps/grist/charts/grist/templates/servicemonitor.yaml
+++ b/helmfile/apps/grist/charts/grist/templates/servicemonitor.yaml
@@ -20,6 +20,7 @@ spec:
   jobLabel: {{ .Values.metrics.serviceMonitor.jobLabel | quote }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 6 }}
+      app.kubernetes.io/component: metrics
       {{- if .Values.metrics.serviceMonitor.selector }}
       {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.selector "context" $) | nindent 6 }}
       {{- end }}

--- a/helmfile/apps/grist/charts/grist/values.yaml
+++ b/helmfile/apps/grist/charts/grist/values.yaml
@@ -221,6 +221,9 @@ replicaCount: 1
 ##
 containerPorts:
   http: 8484
+  ## @param containerPorts.metrics Grist Prometheus metrics container port (requires GRIST_PROMCLIENT_PORT)
+  ##
+  metrics: 9090
 ## Configure extra options for Grist containers' liveness and readiness probes
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
 ## @param livenessProbe.enabled Enable livenessProbe on Grist containers
@@ -795,6 +798,19 @@ metrics:
   ## @param metrics.enabled Enable the export of Prometheus metrics
   ##
   enabled: false
+  ## Metrics service parameters
+  ##
+  service:
+    ## @param metrics.service.ports.metrics Metrics service port
+    ##
+    ports:
+      metrics: 9090
+    ## @param metrics.service.annotations Annotations for the metrics service
+    ##
+    annotations: {}
+    ## @param metrics.service.extraPorts Extra ports for the metrics service
+    ##
+    extraPorts: []
   ## Prometheus Operator ServiceMonitor configuration
   ##
   serviceMonitor:

--- a/helmfile/apps/grist/values-minio.yaml.gotmpl
+++ b/helmfile/apps/grist/values-minio.yaml.gotmpl
@@ -771,6 +771,15 @@ networkPolicy:
         - podSelector:
             matchLabels:
               app.kubernetes.io/part-of: minio
+    {{- if .Values.metric.enabled }}
+    - ports:
+        - port: {{ .Values.objectstore.grist.port }}
+          protocol: TCP
+      from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.metric.namespace }}
+    {{- end }}
   ## @param networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
   ## e.g:
   ## extraEgress:

--- a/helmfile/apps/grist/values-postgresql.yaml.gotmpl
+++ b/helmfile/apps/grist/values-postgresql.yaml.gotmpl
@@ -685,6 +685,15 @@ primary:
           - podSelector:
               matchLabels:
                 app.kubernetes.io/name: grist
+      {{- if .Values.metric.enabled }}
+      - ports:
+          - port: 9187
+            protocol: TCP
+        from:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: {{ .Values.metric.namespace }}
+      {{- end }}
     ## @param primary.networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
     ## e.g:
     ## extraEgress:

--- a/helmfile/apps/grist/values.yaml.gotmpl
+++ b/helmfile/apps/grist/values.yaml.gotmpl
@@ -1,3 +1,7 @@
+{{- /* Single source of truth for Grist's Prometheus metrics port.
+       Drives both the chart's containerPorts.metrics override (below) and
+       the network-policy ingress rule. */ -}}
+{{- $metricsPort := 9090 -}}
 global:
   defaultStorageClass: {{ .Values.pvc.default.storageClass | quote }}
 
@@ -79,6 +83,17 @@ networkPolicy:
    - ports:
        - port: 8484
          protocol: TCP
+   {{- if .Values.metric.enabled }}
+   # Allow Prometheus to scrape metrics. Port is pinned to the chart's
+   # containerPorts.metrics (charts/grist/values.yaml); change both together.
+   - from:
+       - namespaceSelector:
+           matchLabels:
+             kubernetes.io/metadata.name: {{ .Values.metric.namespace }}
+     ports:
+       - port: {{ $metricsPort }}
+         protocol: TCP
+   {{- end }}
 
   # Specific egress rules for required services only
   extraEgress:
@@ -331,3 +346,14 @@ customCss:
       --grist-control-border
       --grist-toast-bg
     */
+
+metrics:
+  enabled: {{ .Values.metric.enabled | default false }}
+  serviceMonitor:
+    enabled: {{ .Values.metric.serviceMonitor.enabled | default false }}
+
+# Pin metrics port so the chart's containerPort and the network-policy
+# ingress rule above cannot drift apart (helmfile values.yaml.gotmpl has
+# no access to the chart's default).
+containerPorts:
+  metrics: {{ $metricsPort }}

--- a/helmfile/apps/keycloak/postgresql.yaml.gotmpl
+++ b/helmfile/apps/keycloak/postgresql.yaml.gotmpl
@@ -684,6 +684,15 @@ primary:
           - podSelector:
               matchLabels:
                 app.kubernetes.io/name: keycloak
+      {{- if .Values.metric.enabled }}
+      - ports:
+          - port: 9187
+            protocol: TCP
+        from:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: {{ .Values.metric.namespace }}
+      {{- end }}
     ## @param primary.networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
     ## e.g:
     ## extraEgress:

--- a/helmfile/apps/meet/values-minio.yaml.gotmpl
+++ b/helmfile/apps/meet/values-minio.yaml.gotmpl
@@ -773,6 +773,15 @@ networkPolicy:
         - podSelector:
             matchLabels:
               app.kubernetes.io/part-of: minio
+    {{- if .Values.metric.enabled }}
+    - ports:
+        - port: {{ .Values.objectstore.meet.port }}
+          protocol: TCP
+      from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.metric.namespace }}
+    {{- end }}
   ## @param networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
   ## e.g:
   ## extraEgress:

--- a/helmfile/apps/meet/values-postgresql.yaml.gotmpl
+++ b/helmfile/apps/meet/values-postgresql.yaml.gotmpl
@@ -694,6 +694,15 @@ primary:
               matchLabels:
                 app.kubernetes.io/name: meet
                 app.kubernetes.io/component: meet-migrate
+      {{- if .Values.metric.enabled }}
+      - ports:
+          - port: 9187
+            protocol: TCP
+        from:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: {{ .Values.metric.namespace }}
+      {{- end }}
     ## @param primary.networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
     ## e.g:
     ## extraEgress:

--- a/helmfile/apps/nextcloud/charts/nextcloud/Chart.yaml
+++ b/helmfile/apps/nextcloud/charts/nextcloud/Chart.yaml
@@ -18,7 +18,7 @@ maintainers:
 name: nextcloud
 sources:
   - https://github.com/nextcloud
-version: 0.1.0
+version: 0.2.0
 dependencies:
   - name: common
     repository: "file://../../../common/charts/common"

--- a/helmfile/apps/nextcloud/charts/nextcloud/templates/_helpers.tpl
+++ b/helmfile/apps/nextcloud/charts/nextcloud/templates/_helpers.tpl
@@ -14,7 +14,25 @@ Return the proper Nextcloud image name
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "nextcloud.imagePullSecrets" -}}
-{{- include "common.images.renderPullSecrets" (dict "images" (list .Values.image ) "context" $) -}}
+{{- include "common.images.renderPullSecrets" (dict "images" (list .Values.image .Values.metrics.image ) "context" $) -}}
+{{- end -}}
+
+{{/*
+Return the proper Nextcloud metrics exporter image name
+*/}}
+{{- define "nextcloud.metrics.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.metrics.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the name of the Secret holding the Nextcloud serverinfo metrics token.
+*/}}
+{{- define "nextcloud.metrics.secretName" -}}
+{{- if .Values.metrics.auth.existingSecret -}}
+{{- tpl .Values.metrics.auth.existingSecret $ -}}
+{{- else -}}
+{{- printf "%s-metrics-token" (include "common.names.fullname" .) -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/helmfile/apps/nextcloud/charts/nextcloud/templates/configmap-script-post-install.yaml
+++ b/helmfile/apps/nextcloud/charts/nextcloud/templates/configmap-script-post-install.yaml
@@ -57,6 +57,36 @@ data:
     # Set default quota for new users
     php /var/www/html/occ config:app:set files default_quota --value="{{ .Values.files.defaultQuota }}"
 
+    {{- if .Values.metrics.enabled }}
+
+    # Wire up the serverinfo app so the Prometheus exporter can authenticate.
+    # The token is generated/kept by the metrics Secret; SERVERINFO_TOKEN is
+    # injected into the main container via env.
+    php /var/www/html/occ app:enable serverinfo || true
+    php /var/www/html/occ config:app:set serverinfo token --value="$SERVERINFO_TOKEN"
+    # phpinfo payload on the serverinfo endpoint is both slow and a minor info
+    # disclosure surface — disable it for scrape use.
+    php /var/www/html/occ config:app:set serverinfo phpinfo --value=""
+
+    # Register the exporter's in-cluster Host header in trusted_domains.
+    # Nextcloud returns HTTP 400 for any request whose Host isn't trusted, so
+    # without this the exporter would receive "unexpected status code: 400" on
+    # every scrape. Idempotent: only appends values not already present.
+    register_trusted_domain() {
+      local host="$1"
+      if php /var/www/html/occ config:system:get trusted_domains 2>/dev/null | grep -Fxq "$host"; then
+        return 0
+      fi
+      local idx=0
+      while php /var/www/html/occ config:system:get trusted_domains "$idx" >/dev/null 2>&1; do
+        idx=$((idx + 1))
+      done
+      php /var/www/html/occ config:system:set trusted_domains "$idx" --value="$host"
+    }
+    register_trusted_domain "{{ include "common.names.fullname" . }}"
+    register_trusted_domain "{{ include "common.names.fullname" . }}:{{ .Values.service.ports.http }}"
+    {{- end }}
+
   {{- if .Values.auth.oidc.enabled }}
   {{- include "nextcloud.addAndEnableAppPreConfig" (dict "appName" "user_oidc" "appTitle" "OIDC Provider" ) | nindent 2 }}
         echo "Configuring OIDC provider..."

--- a/helmfile/apps/nextcloud/charts/nextcloud/templates/deployment.yaml
+++ b/helmfile/apps/nextcloud/charts/nextcloud/templates/deployment.yaml
@@ -199,6 +199,13 @@ spec:
                   name: {{ include "nextcloud.database.secretName" . }}
                   key: {{ include "nextcloud.database.secretPasswordKey" . }}
             {{- end }}
+            {{- if .Values.metrics.enabled }}
+            - name: SERVERINFO_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nextcloud.metrics.secretName" . }}
+                  key: {{ .Values.metrics.auth.secretKey | quote }}
+            {{- end }}
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}

--- a/helmfile/apps/nextcloud/charts/nextcloud/templates/metrics-deployment.yaml
+++ b/helmfile/apps/nextcloud/charts/nextcloud/templates/metrics-deployment.yaml
@@ -1,0 +1,126 @@
+{{- /*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.metrics.enabled }}
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ printf "%s-metrics" (include "common.names.fullname" .) }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: metrics
+  {{- if or .Values.metrics.deploymentAnnotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" (dict "values" (list .Values.metrics.deploymentAnnotations .Values.commonAnnotations) "context" .) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.metrics.replicaCount }}
+  {{- $podLabels := include "common.tplvalues.merge" (dict "values" (list .Values.metrics.podLabels .Values.commonLabels) "context" .) }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+      app.kubernetes.io/component: metrics
+  template:
+    metadata:
+      {{- if .Values.metrics.podAnnotations }}
+      annotations: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.podAnnotations "context" $) | nindent 8 }}
+      {{- end }}
+      labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}
+        app.kubernetes.io/component: metrics
+    spec:
+      {{- include "nextcloud.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ template "nextcloud.serviceAccountName" . }}
+      automountServiceAccountToken: false
+      {{- if .Values.metrics.affinity }}
+      affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.metrics.podAffinityPreset "component" "metrics" "customLabels" $podLabels "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.metrics.podAntiAffinityPreset "component" "metrics" "customLabels" $podLabels "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.metrics.nodeAffinityPreset.type "key" .Values.metrics.nodeAffinityPreset.key "values" .Values.metrics.nodeAffinityPreset.values) | nindent 10 }}
+      {{- end }}
+      {{- if .Values.metrics.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.metrics.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.tolerations "context" .) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.metrics.priorityClassName }}
+      priorityClassName: {{ .Values.metrics.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.metrics.schedulerName }}
+      schedulerName: {{ .Values.metrics.schedulerName | quote }}
+      {{- end }}
+      {{- if .Values.metrics.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.topologySpreadConstraints "context" .) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.metrics.podSecurityContext.enabled }}
+      securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.metrics.podSecurityContext "context" $) | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: metrics
+          image: {{ include "nextcloud.metrics.image" . }}
+          imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
+          {{- if .Values.metrics.containerSecurityContext.enabled }}
+          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.metrics.containerSecurityContext "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.diagnosticMode.enabled }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
+          {{- end }}
+          env:
+            - name: NEXTCLOUD_SERVER
+              value: {{ printf "http://%s:%d" (include "common.names.fullname" .) (int .Values.service.ports.http) | quote }}
+            - name: NEXTCLOUD_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nextcloud.metrics.secretName" . }}
+                  key: {{ .Values.metrics.auth.secretKey | quote }}
+            - name: NEXTCLOUD_TIMEOUT
+              value: {{ .Values.metrics.timeout | quote }}
+            - name: NEXTCLOUD_INFO_APPS
+              value: {{ .Values.metrics.enableInfoApps | quote }}
+            - name: NEXTCLOUD_INFO_UPDATE
+              value: {{ .Values.metrics.enableInfoUpdate | quote }}
+            - name: NEXTCLOUD_LISTEN_ADDRESS
+              value: {{ printf ":%d" (int .Values.metrics.containerPorts.metrics) | quote }}
+            - name: NEXTCLOUD_TLS_SKIP_VERIFY
+              value: "false"
+            {{- if .Values.metrics.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.metrics.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: tcp-metrics
+              containerPort: {{ .Values.metrics.containerPorts.metrics }}
+              protocol: TCP
+          {{- if not .Values.diagnosticMode.enabled }}
+          {{- if .Values.metrics.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.metrics.livenessProbe.enabled }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.metrics.livenessProbe "enabled") "context" $) | nindent 12 }}
+            tcpSocket:
+              port: tcp-metrics
+          {{- end }}
+          {{- if .Values.metrics.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.metrics.readinessProbe.enabled }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.metrics.readinessProbe "enabled") "context" $) | nindent 12 }}
+            tcpSocket:
+              port: tcp-metrics
+          {{- end }}
+          {{- if .Values.metrics.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.metrics.startupProbe.enabled }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.metrics.startupProbe "enabled") "context" $) | nindent 12 }}
+            httpGet:
+              path: /metrics
+              port: tcp-metrics
+          {{- end }}
+          {{- end }}
+          {{- if .Values.metrics.resources }}
+          resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
+          {{- else if ne .Values.metrics.resourcesPreset "none" }}
+          resources: {{- include "common.resources.preset" (dict "type" .Values.metrics.resourcesPreset) | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/helmfile/apps/nextcloud/charts/nextcloud/templates/metrics-networkpolicy.yaml
+++ b/helmfile/apps/nextcloud/charts/nextcloud/templates/metrics-networkpolicy.yaml
@@ -1,0 +1,55 @@
+{{- /*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if and .Values.metrics.enabled .Values.metrics.networkPolicy.enabled }}
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: {{ printf "%s-metrics" (include "common.names.fullname" .) }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: metrics
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.podLabels .Values.commonLabels ) "context" . ) }}
+  podSelector:
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+      app.kubernetes.io/component: metrics
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    # DNS resolution
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Egress to Nextcloud HTTP endpoint (serverinfo API)
+    - ports:
+        - port: {{ .Values.containerPorts.http }}
+          protocol: TCP
+      to:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+              app.kubernetes.io/component: nextcloud
+    {{- if .Values.metrics.networkPolicy.extraEgress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
+    {{- end }}
+  ingress:
+    # Prometheus Operator scrape from the monitoring namespace
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.metrics.networkPolicy.monitoringNamespace | quote }}
+      ports:
+        - port: {{ .Values.metrics.containerPorts.metrics }}
+          protocol: TCP
+    {{- if .Values.metrics.networkPolicy.extraIngress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.networkPolicy.extraIngress "context" $ ) | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/helmfile/apps/nextcloud/charts/nextcloud/templates/metrics-secret.yaml
+++ b/helmfile/apps/nextcloud/charts/nextcloud/templates/metrics-secret.yaml
@@ -1,0 +1,22 @@
+{{- /*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if and .Values.metrics.enabled (not .Values.metrics.auth.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-metrics-token" (include "common.names.fullname" .) }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: metrics
+  annotations:
+    helm.sh/resource-policy: keep
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+type: Opaque
+data:
+  {{ .Values.metrics.auth.secretKey }}: {{ include "common.secrets.passwords.manage" (dict "secret" (printf "%s-metrics-token" (include "common.names.fullname" .)) "key" .Values.metrics.auth.secretKey "providedValues" (list "metrics.auth.token") "length" 64 "strong" false "context" $) }}
+{{- end }}

--- a/helmfile/apps/nextcloud/charts/nextcloud/templates/metrics-service.yaml
+++ b/helmfile/apps/nextcloud/charts/nextcloud/templates/metrics-service.yaml
@@ -1,0 +1,28 @@
+{{- /*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ printf "%s-metrics" (include "common.names.fullname" .) }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" .) | nindent 4 }}
+    app.kubernetes.io/component: metrics
+  {{- if or .Values.metrics.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" (dict "values" (list .Values.metrics.service.annotations .Values.commonAnnotations) "context" .) }}
+  annotations: {{- include "common.tplvalues.render" (dict "value" $annotations "context" .) | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: tcp-metrics
+      port: {{ .Values.metrics.service.ports.metrics }}
+      protocol: TCP
+      targetPort: tcp-metrics
+  {{- $podLabels := include "common.tplvalues.merge" (dict "values" (list .Values.metrics.podLabels .Values.commonLabels) "context" .) | fromYaml }}
+  selector: {{- include "common.labels.matchLabels" (dict "customLabels" $podLabels "context" .) | nindent 4 }}
+    app.kubernetes.io/component: metrics
+{{- end }}

--- a/helmfile/apps/nextcloud/charts/nextcloud/templates/servicemonitor.yaml
+++ b/helmfile/apps/nextcloud/charts/nextcloud/templates/servicemonitor.yaml
@@ -20,6 +20,7 @@ spec:
   jobLabel: {{ .Values.metrics.serviceMonitor.jobLabel | quote }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 6 }}
+      app.kubernetes.io/component: metrics
       {{- if .Values.metrics.serviceMonitor.selector }}
       {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.selector "context" $) | nindent 6 }}
       {{- end }}

--- a/helmfile/apps/nextcloud/charts/nextcloud/values.yaml
+++ b/helmfile/apps/nextcloud/charts/nextcloud/values.yaml
@@ -925,12 +925,238 @@ serviceAccount:
   ##
   automountServiceAccountToken: true
 
-## Prometheus metrics
+## @section Metrics Parameters
+##
+## Prometheus metrics for Nextcloud.
+##
+## Nextcloud does not expose a native Prometheus endpoint. Metrics are produced
+## by `xperimental/nextcloud-exporter`, which queries the `serverinfo` OCS API
+## and re-exposes OpenMetrics. The exporter runs as its OWN Deployment (not a
+## sidecar) because `serverinfo` returns cluster-wide scalars; one exporter
+## replica therefore gives a single authoritative time series regardless of
+## Nextcloud HPA replica count, and scrape cost is bounded.
+##
+## Operators: import Grafana dashboard ID 11033 for the exporter's metrics.
+## ref: https://grafana.com/grafana/dashboards/11033
 ##
 metrics:
-  ## @param metrics.enabled Enable the export of Prometheus metrics
+  ## @param metrics.enabled Deploy the Nextcloud Prometheus exporter
   ##
   enabled: false
+  ## Nextcloud exporter image
+  ## ref: https://github.com/xperimental/nextcloud-exporter
+  ## @param metrics.image.registry Nextcloud exporter image registry
+  ## @param metrics.image.repository Nextcloud exporter image repository
+  ## @param metrics.image.tag Nextcloud exporter image tag (immutable tags are recommended)
+  ## @param metrics.image.digest Nextcloud exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
+  ## @param metrics.image.pullPolicy Nextcloud exporter image pull policy
+  ## @param metrics.image.pullSecrets Specify image pull secrets
+  ##
+  image:
+    registry: docker.io
+    repository: xperimental/nextcloud-exporter
+    tag: "0.9.1"
+    digest: ""
+    pullPolicy: IfNotPresent
+    pullSecrets: []
+  ## @param metrics.replicaCount Number of exporter replicas (should be 1 — serverinfo is cluster-wide)
+  ##
+  replicaCount: 1
+  ## @param metrics.timeout HTTP timeout for the serverinfo call (serverinfo can take 30-50s)
+  ##
+  timeout: "45s"
+  ## @param metrics.enableInfoApps Include the `info.apps` section of serverinfo in scrapes (slow; leave off unless you need per-app metrics)
+  ##
+  enableInfoApps: false
+  ## @param metrics.enableInfoUpdate Include the `info.update` section of serverinfo in scrapes (slow; Nextcloud upgrades are manual)
+  ##
+  enableInfoUpdate: false
+  ## Authentication for the serverinfo endpoint
+  ## A random 64-char alphanumeric token is auto-generated and stored in a Secret
+  ## (kept across upgrades via `common.secrets.passwords.manage`). The token
+  ## is provisioned into Nextcloud by the post-install script
+  ## (`occ config:app:set serverinfo token`).
+  ##
+  auth:
+    ## @param metrics.auth.existingSecret Name of an existing Secret holding the serverinfo token. If empty, a Secret is created.
+    ##
+    existingSecret: ""
+    ## @param metrics.auth.secretKey Key inside the Secret that holds the serverinfo token
+    ##
+    secretKey: "token"
+  ## @param metrics.extraEnvVars Extra env vars for the exporter container
+  ##
+  extraEnvVars: []
+  ## @param metrics.containerPorts.metrics Exporter HTTP port
+  ##
+  containerPorts:
+    metrics: 9205
+  ## Exporter pod security context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  ## @param metrics.podSecurityContext.enabled Enable exporter pod-level securityContext
+  ## @param metrics.podSecurityContext.fsGroup Group ID for the exporter pod's volumes
+  ## @param metrics.podSecurityContext.runAsUser UID the exporter pod should run as
+  ## @param metrics.podSecurityContext.runAsGroup GID the exporter pod should run as
+  ## @param metrics.podSecurityContext.runAsNonRoot Require the exporter pod to run as non-root
+  ## @param metrics.podSecurityContext.seccompProfile.type Exporter pod seccomp profile
+  ##
+  podSecurityContext:
+    enabled: true
+    fsGroup: 1001
+    runAsUser: 1001
+    runAsGroup: 1001
+    runAsNonRoot: true
+    seccompProfile:
+      type: "RuntimeDefault"
+  ## Exporter container security context
+  ## @param metrics.containerSecurityContext.enabled Enable exporter container-level securityContext
+  ## @param metrics.containerSecurityContext.runAsUser Exporter container UID
+  ## @param metrics.containerSecurityContext.runAsGroup Exporter container GID
+  ## @param metrics.containerSecurityContext.runAsNonRoot Require exporter container runAsNonRoot
+  ## @param metrics.containerSecurityContext.privileged Run exporter container privileged
+  ## @param metrics.containerSecurityContext.readOnlyRootFilesystem Exporter container read-only root filesystem
+  ## @param metrics.containerSecurityContext.allowPrivilegeEscalation Allow privilege escalation in exporter container
+  ## @param metrics.containerSecurityContext.capabilities.drop Capabilities to drop from the exporter container
+  ## @param metrics.containerSecurityContext.seccompProfile.type Exporter container seccomp profile
+  ##
+  containerSecurityContext:
+    enabled: true
+    runAsUser: 1001
+    runAsGroup: 1001
+    runAsNonRoot: true
+    privileged: false
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+    seccompProfile:
+      type: "RuntimeDefault"
+  ## Exporter probes
+  ## @param metrics.livenessProbe.enabled Enable livenessProbe on the exporter container
+  ## @param metrics.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+  ## @param metrics.livenessProbe.periodSeconds Period seconds for livenessProbe
+  ## @param metrics.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+  ## @param metrics.livenessProbe.failureThreshold Failure threshold for livenessProbe
+  ## @param metrics.livenessProbe.successThreshold Success threshold for livenessProbe
+  ##
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+  ## @param metrics.readinessProbe.enabled Enable readinessProbe on the exporter container
+  ## @param metrics.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+  ## @param metrics.readinessProbe.periodSeconds Period seconds for readinessProbe
+  ## @param metrics.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+  ## @param metrics.readinessProbe.failureThreshold Failure threshold for readinessProbe
+  ## @param metrics.readinessProbe.successThreshold Success threshold for readinessProbe
+  ##
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 30
+    timeoutSeconds: 50
+    failureThreshold: 6
+    successThreshold: 1
+  ## @param metrics.startupProbe.enabled Enable startupProbe on the exporter container
+  ## @param metrics.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+  ## @param metrics.startupProbe.periodSeconds Period seconds for startupProbe
+  ## @param metrics.startupProbe.timeoutSeconds Timeout seconds for startupProbe
+  ## @param metrics.startupProbe.failureThreshold Failure threshold for startupProbe
+  ## @param metrics.startupProbe.successThreshold Success threshold for startupProbe
+  ##
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 30
+    successThreshold: 1
+  ## @param metrics.customLivenessProbe Custom livenessProbe that overrides the default one
+  ##
+  customLivenessProbe: {}
+  ## @param metrics.customReadinessProbe Custom readinessProbe that overrides the default one
+  ##
+  customReadinessProbe: {}
+  ## @param metrics.customStartupProbe Custom startupProbe that overrides the default one
+  ##
+  customStartupProbe: {}
+  ## @param metrics.resourcesPreset Exporter container resources preset. Ignored if metrics.resources is set.
+  ## More information: https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
+  ##
+  resourcesPreset: "nano"
+  ## @param metrics.resources Exporter container resources
+  ##
+  resources: {}
+  ## @param metrics.podLabels Extra labels for the exporter pod
+  ##
+  podLabels: {}
+  ## @param metrics.podAnnotations Extra annotations for the exporter pod
+  ##
+  podAnnotations: {}
+  ## @param metrics.deploymentAnnotations Extra annotations for the exporter Deployment
+  ##
+  deploymentAnnotations: {}
+  ## @param metrics.affinity Affinity rules for exporter pod assignment
+  ##
+  affinity: {}
+  ## @param metrics.nodeSelector Node labels for exporter pod assignment
+  ##
+  nodeSelector: {}
+  ## @param metrics.tolerations Tolerations for exporter pod assignment
+  ##
+  tolerations: []
+  ## @param metrics.priorityClassName priorityClassName for the exporter pod
+  ##
+  priorityClassName: ""
+  ## @param metrics.schedulerName Scheduler name for the exporter pod
+  ##
+  schedulerName: ""
+  ## @param metrics.topologySpreadConstraints Topology spread constraints for the exporter pod
+  ##
+  topologySpreadConstraints: []
+  ## @param metrics.podAffinityPreset Exporter pod affinity preset. Allowed values: soft, hard
+  ##
+  podAffinityPreset: ""
+  ## @param metrics.podAntiAffinityPreset Exporter pod anti-affinity preset. Allowed values: soft, hard
+  ##
+  podAntiAffinityPreset: soft
+  ## @param metrics.nodeAffinityPreset.type Exporter node affinity preset type. Allowed values: soft, hard
+  ## @param metrics.nodeAffinityPreset.key Exporter node label key to match
+  ## @param metrics.nodeAffinityPreset.values Exporter node label values to match
+  ##
+  nodeAffinityPreset:
+    type: ""
+    key: ""
+    values: []
+  ## Metrics service parameters
+  ##
+  service:
+    ## @param metrics.service.ports.metrics Metrics service port
+    ##
+    ports:
+      metrics: 9205
+    ## @param metrics.service.annotations Annotations for the metrics service
+    ##
+    annotations: {}
+  ## NetworkPolicy dedicated to the exporter pod
+  ## Allows monitoring namespace to scrape, and exporter to reach Nextcloud.
+  ##
+  networkPolicy:
+    ## @param metrics.networkPolicy.enabled Create a NetworkPolicy for the exporter pod
+    ##
+    enabled: true
+    ## @param metrics.networkPolicy.monitoringNamespace Name of the namespace hosting the Prometheus installation permitted to scrape this exporter. Override this (or pipe `metric.namespace` through from helmfile values) if Prometheus runs elsewhere.
+    ##
+    monitoringNamespace: "monitoring"
+    ## @param metrics.networkPolicy.extraIngress Additional ingress rules for the exporter pod
+    ##
+    extraIngress: []
+    ## @param metrics.networkPolicy.extraEgress Additional egress rules for the exporter pod
+    ##
+    extraEgress: []
   ## Prometheus Operator ServiceMonitor configuration
   ##
   serviceMonitor:
@@ -956,17 +1182,13 @@ metrics:
     ##
     tlsConfig: {}
     ## @param metrics.serviceMonitor.interval Interval at which metrics should be scraped.
-    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
-    ## e.g:
-    ## interval: 10s
+    ## Defaults to 90s because the serverinfo endpoint is expensive (30-50s). Lowering this risks overlapping scrapes and added DB load.
     ##
-    interval: ""
-    ## @param metrics.serviceMonitor.scrapeTimeout Timeout after which the scrape is ended
-    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
-    ## e.g:
-    ## scrapeTimeout: 10s
+    interval: "90s"
+    ## @param metrics.serviceMonitor.scrapeTimeout Timeout after which the scrape is ended.
+    ## Must be >= metrics.timeout so slow serverinfo responses are not dropped.
     ##
-    scrapeTimeout: ""
+    scrapeTimeout: "50s"
     ## @param metrics.serviceMonitor.metricRelabelings Specify additional relabeling of metrics
     ##
     metricRelabelings: []

--- a/helmfile/apps/nextcloud/values-minio.yaml.gotmpl
+++ b/helmfile/apps/nextcloud/values-minio.yaml.gotmpl
@@ -760,6 +760,15 @@ networkPolicy:
         - podSelector:
             matchLabels:
               app.kubernetes.io/part-of: minio
+    {{- if .Values.metric.enabled }}
+    - ports:
+        - port: {{ .Values.objectstore.nextcloud.port }}
+          protocol: TCP
+      from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.metric.namespace }}
+    {{- end }}
   ## @param networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
   ## e.g:
   ## extraEgress:

--- a/helmfile/apps/nextcloud/values-postgresql.yaml.gotmpl
+++ b/helmfile/apps/nextcloud/values-postgresql.yaml.gotmpl
@@ -685,6 +685,15 @@ primary:
           - podSelector:
               matchLabels:
                 app.kubernetes.io/name: nextcloud
+      {{- if .Values.metric.enabled }}
+      - ports:
+          - port: 9187
+            protocol: TCP
+        from:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: {{ .Values.metric.namespace }}
+      {{- end }}
     ## @param primary.networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
     ## e.g:
     ## extraEgress:

--- a/helmfile/apps/nextcloud/values.yaml.gotmpl
+++ b/helmfile/apps/nextcloud/values.yaml.gotmpl
@@ -61,6 +61,18 @@ networkPolicy:
    - ports:
        - port: 8080
          protocol: TCP
+   {{- if .Values.metric.enabled }}
+   # Allow the in-namespace metrics exporter pod to reach Nextcloud's
+   # serverinfo endpoint. Prometheus itself scrapes the exporter pod, not
+   # Nextcloud — see the dedicated metrics NetworkPolicy.
+   - from:
+       - podSelector:
+           matchLabels:
+             app.kubernetes.io/component: metrics
+     ports:
+       - port: 8080
+         protocol: TCP
+   {{- end }}
 
   # Specific egress rules for required services only
   extraEgress:
@@ -217,3 +229,10 @@ files:
     maxStreamSize: {{ .Values.antivirus.streamMaxLength }}
     infectedAction: delete
     maxFileSize: {{ .Values.antivirus.mailFilter.maxFileSize }}
+
+metrics:
+  enabled: {{ .Values.metric.enabled | default false }}
+  networkPolicy:
+    monitoringNamespace: {{ .Values.metric.namespace | quote }}
+  serviceMonitor:
+    enabled: {{ .Values.metric.serviceMonitor.enabled | default false }}

--- a/helmfile/apps/openproject/values-minio.yaml.gotmpl
+++ b/helmfile/apps/openproject/values-minio.yaml.gotmpl
@@ -771,6 +771,15 @@ networkPolicy:
         - podSelector:
             matchLabels:
               app.kubernetes.io/part-of: minio
+    {{- if .Values.metric.enabled }}
+    - ports:
+        - port: {{ .Values.objectstore.openproject.port }}
+          protocol: TCP
+      from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.metric.namespace }}
+    {{- end }}
   ## @param networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
   ## e.g:
   ## extraEgress:

--- a/helmfile/apps/openproject/values-postgresql.yaml.gotmpl
+++ b/helmfile/apps/openproject/values-postgresql.yaml.gotmpl
@@ -685,6 +685,15 @@ primary:
           - podSelector:
               matchLabels:
                 app.kubernetes.io/part-of: openproject
+      {{- if .Values.metric.enabled }}
+      - ports:
+          - port: 9187
+            protocol: TCP
+        from:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: {{ .Values.metric.namespace }}
+      {{- end }}
     ## @param primary.networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
     ## e.g:
     ## extraEgress:

--- a/helmfile/environments/default/metric.yaml.gotmpl
+++ b/helmfile/environments/default/metric.yaml.gotmpl
@@ -1,6 +1,12 @@
 metric:
   enabled: false
 
+  # Namespace where the cluster's Prometheus installation lives. Used by
+  # per-app NetworkPolicy ingress rules so only the Prometheus server is
+  # allowed to scrape metrics endpoints. Override in an env-specific values
+  # file if Prometheus isn't deployed to "monitoring".
+  namespace: "monitoring"
+
   # if you enable these options you need to make sure you have the https://prometheus-operator.dev/ installed
   serviceMonitor:
     enabled: false


### PR DESCRIPTION
# Description

Adds Prometheus Operator `ServiceMonitor`-based observability across the platform. Every enabled app's exporter is now scraped by the in-cluster `kube-prometheus-stack`, with NetworkPolicies opened just enough to let the `monitoring` namespace reach each metrics endpoint.

  **Per app:**
  - **PostgreSQL / MinIO** (shared subcharts): monitoring-ns ingress allowances added to every app that uses them.
  - **Synapse**: `ServiceMonitor` + metrics `Service`; scrape path set to `/_synapse/metrics` (Synapse's non-default path).
  - **Grist**: `ServiceMonitor` + metrics `Service`.
  - **Nextcloud**: runs `xperimental/nextcloud-exporter` as a separate single-replica `Deployment` (not a sidecar — `serverinfo` returns cluster-wide scalars, so sidecarring would N-multiply scrape cost and duplicate series under HPA). Auth via a chart-generated serverinfo token stored in a Secret and provisioned into Nextcloud by the existing post-install script. Post-install also registers the in-cluster Host header in `trusted_domains`, without which Nextcloud returns HTTP 400 on the scrape. Matches upstream `nextcloud/helm`'s env-var configuration shape.

For Synapse and Grist, the metrics container port is now pinned via a single `$metricsPort` gotmpl constant so the chart's containerPort and the NetworkPolicy ingress rule can't drift apart.

Resolves #104 

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x] I have followed the project's style guidelines by running the relevant scripts/\* tools.
- [x] I have rebased my branch onto the latest commit of the main branch.
- [x] I have squashed or reorganized my commits into logical units.
- [x] I have updated documentation.
