### PR TITLE
📝 docs: fix predicted_resources.py path (script → scripts)

### DIFF
--- a/docs/docs/getting_started/prerequisites.md
+++ b/docs/docs/getting_started/prerequisites.md
@@ -25,7 +25,7 @@ MijnBureau has minimal prerequisites, requiring only a Kubernetes cluster and so
 
 ### Kubernetes Resources
 
-MijnBureau simplifies resource setup with a global size parameter that adjusts resource usage for all components. Below is the expected resource usage based on the size parameter only. For precise calculations, use the `./script/predicted_resources.py` script.
+MijnBureau simplifies resource setup with a global size parameter that adjusts resource usage for all components. Below is the expected resource usage based on the size parameter only. For precise calculations, use the `./scripts/predicted_resources.py` script.
 
 #### Resource Usage by Size
 


### PR DESCRIPTION
The prerequisites guide referenced ./script/predicted_resources.py but the directory is scripts/ (plural). Corrected so the documented command works.

# Description

Fixes the typo

Resolves https://github.com/MinBZK/mijn-bureau-infra/issues/617

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x] I have followed the project's style guidelines by running the relevant scripts/\* tools.
- [x] I have rebased my branch onto the latest commit of the main branch.
- [x] I have squashed or reorganized my commits into logical units.
- [x] I have updated documentation.
