### PR TITLE
🐛(grist) fix transparent sidebar

### DIFF
--- a/helmfile/apps/grist/values.yaml.gotmpl
+++ b/helmfile/apps/grist/values.yaml.gotmpl
@@ -229,7 +229,7 @@ customCss:
         --grist-theme-very-light: var(--grist-theme-white); /* text that is always light, whatever the current appearance (light or dark theme) */
 
         --grist-theme-bg-default: #fff; /* default body bg color */
-        --grist-theme-bg-secondary: #1b1b230d; /* bg color mostly used on panels */
+        --grist-theme-bg-secondary: #f3f3f4; /* bg color mostly used on panels */
         --grist-theme-bg-tertiary: #1b1b230d; /* transparent bg, mostly used on hover effects */
         --grist-theme-bg-emphasis: #154273; /* pronounced bg color, mostly used on selected items */
 


### PR DESCRIPTION
# Description

Fix transparent sidebar on Grist

Resolves: https://github.com/MinBZK/mijn-bureau-infra/issues/619

Before:

<img width="1448" height="1748" alt="image" src="https://github.com/user-attachments/assets/e410fb6a-4bb7-45cc-9213-7b544be97410" />

After:

<img width="1676" height="1528" alt="image" src="https://github.com/user-attachments/assets/1a220fc1-b93d-4ccc-a96a-3e1f3aa05d9a" />


## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x] I have followed the project's style guidelines by running the relevant scripts/\* tools.
- [x] I have rebased my branch onto the latest commit of the main branch.
- [x] I have squashed or reorganized my commits into logical units.
- [ ] I have updated documentation.
