### PR TITLE
✨(ci) Add 'Signed-off-by' validation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,5 +14,5 @@ Please check all the boxes that apply to this pull request using "x":
 - [ ] I have rebased my branch onto the latest commit of the main branch.
 - [ ] I have squashed or reorganized my commits into logical units.
 - [ ] I have updated documentation.
-- [ ] I have followed the [AI-assisted coding guidelines](/docs/docs/development/AI-Coding-Assistants.md).
-- [ ] I have signed off my commits with `git commit --signoff` (DCO compliance) and agree to the [DCO](/DCO.md)
+- [ ] I have followed the [AI-assisted coding guidelines](/MinBZK/mijn-bureau-infra/blob/main/docs/docs/development/AI-Coding-Assistants.md).
+- [ ] I have signed off my commits with `git commit --signoff` (DCO compliance) and agree to the [DCO](/MinBZK/mijn-bureau-infra/blob/main/DCO.md)

--- a/.gitlint
+++ b/.gitlint
@@ -16,3 +16,7 @@ ignore=B6
 [ignore-by-author-name]
 regex=dependabot
 ignore=all
+
+[ignore-by-body]
+regex=Signed-off-by:
+ignore=body-max-line-length

--- a/scripts/gitlint_emoji.py
+++ b/scripts/gitlint_emoji.py
@@ -6,9 +6,10 @@ from __future__ import unicode_literals
 
 import os
 import re
+from typing import Any
 
 import requests
-from gitlint.rules import CommitMessageTitle, LineRule, RuleViolation
+from gitlint.rules import CommitMessageTitle, LineRule, RuleViolation, CommitRule
 
 
 class GitmojiTitle(LineRule):
@@ -22,7 +23,7 @@ class GitmojiTitle(LineRule):
     name = "title-should-have-gitmoji-and-scope"
     target = CommitMessageTitle
 
-    def validate(self, title, _commit):
+    def validate(self, title: str, _commit: Any):
         """
         Download the list possible gitmojis from the project's github repository and check that
         title contains one of them.
@@ -57,3 +58,40 @@ class GitmojiTitle(LineRule):
         if not re.search(pattern, title):
             violation_msg = 'The scope should be one of: {:s}'.format(", ".join(scopes))
             return [RuleViolation(self.id, violation_msg, title)]
+
+
+# also add a sign-off check to the gitlint config file, to ensure that all commits are signed off
+class SignOff(CommitRule):
+    """
+    This rule will enforce that each commit message contains a sign-off line.
+    """
+
+    id = "UC2"
+    name = "commit-should-have-sign-off"
+
+    def _message_to_text(self, message: Any) -> str:
+        """Convert a gitlint commit message object to plain text."""
+        if isinstance(message, str):
+            return message
+
+        full = getattr(message, "full", None)
+        if isinstance(full, str):
+            return full
+
+        title = getattr(message, "title", "")
+        body = getattr(message, "body", "")
+        title_text = title if isinstance(title, str) else str(title)
+        body_text = body if isinstance(body, str) else str(body)
+
+        combined = "\n\n".join(part for part in [title_text, body_text] if part)
+        return combined if combined else str(message)
+
+    def validate(self, commit: Any):
+        """
+        Check if the commit message contains a sign-off line.
+        """
+        sign_off_pattern = r"^Signed-off-by: (.+) <(.+)>$"
+        message_text = self._message_to_text(commit.message)
+        if not re.search(sign_off_pattern, message_text, re.MULTILINE):
+            violation_msg = "Commit message does not contain a sign-off line."
+            return [RuleViolation(self.id, violation_msg, message_text)]


### PR DESCRIPTION
# Description

Add signoff check to adhere to DCO

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x] I have followed the project's style guidelines by running the relevant scripts/\* tools.
- [x] I have rebased my branch onto the latest commit of the main branch.
- [x] I have squashed or reorganized my commits into logical units.
- [x] I have updated documentation.
- [x] I have followed the [AI-assisted coding guidelines](/docs/docs/development/AI-Coding-Assistants.md).
- [x] I have signed off my commits with `git commit --signoff` (DCO compliance) and agree to the [DCO](/DCO.md)
